### PR TITLE
refactor: cleanup packfile code

### DIFF
--- a/plumbing/packfile/packfile.go
+++ b/plumbing/packfile/packfile.go
@@ -31,10 +31,13 @@ const (
 	packfileHeaderSize = 12
 )
 
-var (
-	packfileMagic   = []byte{'P', 'A', 'C', 'K'}
-	packfileVersion = []byte{0, 0, 0, 2}
-)
+func packfileMagic() []byte {
+	return []byte{'P', 'A', 'C', 'K'}
+}
+
+func packfileVersion() []byte {
+	return []byte{0, 0, 0, 2}
+}
 
 var (
 	// ErrIntOverflow is an error thrown when the packfile couldn't
@@ -105,10 +108,10 @@ func NewFromFile(objectGetter ObjectGetter, filePath string) (*Pack, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("could read header of index file: %w", err)
 	}
-	if !bytes.Equal(header[0:4], packfileMagic) {
+	if !bytes.Equal(header[0:4], packfileMagic()) {
 		return nil, xerrors.Errorf("invalid header: %w", ErrInvalidMagic)
 	}
-	if !bytes.Equal(header[4:8], packfileVersion) {
+	if !bytes.Equal(header[4:8], packfileVersion()) {
 		return nil, xerrors.Errorf("invalid header: %w", ErrInvalidVersion)
 	}
 

--- a/plumbing/packfile/packfile.go
+++ b/plumbing/packfile/packfile.go
@@ -112,10 +112,10 @@ func NewFromFile(objectGetter ObjectGetter, filePath string) (*Pack, error) {
 		return nil, xerrors.Errorf("invalid header: %w", ErrInvalidVersion)
 	}
 
-	IndexFilePath := strings.TrimSuffix(filePath, ExtPackfile) + ExtIndex
-	idx, err := NewIndexFromFile(IndexFilePath)
+	indexFilePath := strings.TrimSuffix(filePath, ExtPackfile) + ExtIndex
+	idx, err := NewIndexFromFile(indexFilePath)
 	if err != nil {
-		return nil, xerrors.Errorf("could not open index file at %s: %w", IndexFilePath, err)
+		return nil, xerrors.Errorf("could not open index file at %s: %w", indexFilePath, err)
 	}
 
 	return &Pack{


### PR DESCRIPTION
The goal of this PR is to clean up the packfile read operations to prepare the adding support for write operations.

What it does:

- Remove global variables to make sure hardcoded values are immutable.

TODO:
- [ ] Investigate handling concurrency
- [ ] Investigate performances (memory used, syscall, etc.)