### PR TITLE
ci: revert workflow to push to prevent CC issue

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,5 @@
 name: Go
-on: [pull_request]
+on: [push]
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
When using `pull_request`, `$GITHUB_REF` contains info on the pull request (ex: `refs/pull/24/merge`) instead of the branch name. Since this is a small personal project, it makes more sense to just go with `push` rather than trying to figure out how to get the branch name in a `pull_request` workflow.