### PR TITLE
ci: update golangci-lint to v1.29

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v1
         with:
-          version: v1.28
+          version: v1.29
 
   build:
     name: Build


### PR DESCRIPTION
Changelog: https://github.com/golangci/golangci-lint/releases/tag/v1.29.0