### PR TITLE
ci: target v0 for Nancy

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
         # - CVE-2020-15114
         # - CVE-2020-15115
         # - CVE-2020-15136
-        run: go list -m all | docker run -i sonatypecommunity/nancy:latest -exclude-vulnerability=CVE-2020-15114,CVE-2020-15115,CVE-2020-15136
+        run: go list -m all | docker run -i sonatypecommunity/nancy:v0 -exclude-vulnerability=CVE-2020-15114,CVE-2020-15115,CVE-2020-15136
 
   lint:
     name: Lint


### PR DESCRIPTION
Nancy follows semver and is about to release [v1.0](https://github.com/sonatype-nexus-community/nancy/pull/161). To prevent getting hit by breaking change, we'll target v0 for now.