### PR TITLE
test: cleanup tests

### DIFF
--- a/backend/fsbackend/fsbackend_test.go
+++ b/backend/fsbackend/fsbackend_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestInit(t *testing.T) {
+	t.Parallel()
+
 	t.Run("regular repo should work", func(t *testing.T) {
 		t.Parallel()
 

--- a/backend/fsbackend/fsbackend_test.go
+++ b/backend/fsbackend/fsbackend_test.go
@@ -20,7 +20,7 @@ func TestInit(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		err := fsbackend.New(filepath.Join(dir, gitpath.DotGitPath)).Init()
 		require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestInit(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		err := fsbackend.New(dir).Init()
 		require.NoError(t, err)
@@ -40,7 +40,7 @@ func TestInit(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		// create a directory
 		err := os.MkdirAll(filepath.Join(dir, gitpath.ObjectsPath), 0o750)
@@ -63,7 +63,7 @@ func TestInit(t *testing.T) {
 		}
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		// create a directory
 		err := os.MkdirAll(filepath.Join(dir, gitpath.ObjectsPath), 0o550)
@@ -80,7 +80,7 @@ func TestInit(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		// create a file
 		err := ioutil.WriteFile(filepath.Join(dir, gitpath.DescriptionPath), []byte{}, 0o444)

--- a/backend/fsbackend/objects_test.go
+++ b/backend/fsbackend/objects_test.go
@@ -22,7 +22,7 @@ func TestObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		oid, err := ginternals.NewOidFromStr("b07e28976ac8972715598f390964d53cf4dbc1bd")
 		require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		oid, err := ginternals.NewOidFromStr("1dcdadc2a420225783794fbffd51e2e137a69646")
 		require.NoError(t, err)
@@ -59,7 +59,7 @@ func TestObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		oid, err := ginternals.NewOidFromStr("2dcdadc2a420225783794fbffd51e2e137a69646")
 		require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestHasObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 
@@ -93,7 +93,7 @@ func TestHasObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 
@@ -109,7 +109,7 @@ func TestHasObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 
@@ -136,7 +136,7 @@ func TestHasObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 
@@ -162,7 +162,7 @@ func TestWriteObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		dotGitPath := filepath.Join(repoPath, gitpath.DotGitPath)
 		b := New(dotGitPath)
@@ -190,7 +190,7 @@ func TestWriteObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		dotGitPath := filepath.Join(repoPath, gitpath.DotGitPath)
 		b := New(dotGitPath)

--- a/backend/fsbackend/objects_test.go
+++ b/backend/fsbackend/objects_test.go
@@ -73,6 +73,8 @@ func TestObject(t *testing.T) {
 }
 
 func TestHasObject(t *testing.T) {
+	t.Parallel()
+
 	t.Run("existing object should exist", func(t *testing.T) {
 		t.Parallel()
 

--- a/backend/fsbackend/reference_test.go
+++ b/backend/fsbackend/reference_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestReference(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Should fail if reference doesn't exists", func(t *testing.T) {
 		t.Parallel()
 
@@ -65,6 +67,8 @@ func TestReference(t *testing.T) {
 }
 
 func TestParsePackedRefs(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Should return empty list if no files", func(t *testing.T) {
 		t.Parallel()
 
@@ -142,6 +146,8 @@ func TestParsePackedRefs(t *testing.T) {
 }
 
 func TestWriteReference(t *testing.T) {
+	t.Parallel()
+
 	t.Run("should pass writing a new symbolic reference", func(t *testing.T) {
 		t.Parallel()
 
@@ -249,6 +255,8 @@ func TestWriteReference(t *testing.T) {
 }
 
 func TestWriteReferenceSafe(t *testing.T) {
+	t.Parallel()
+
 	t.Run("should pass writing a new symbolic reference", func(t *testing.T) {
 		t.Parallel()
 

--- a/backend/fsbackend/reference_test.go
+++ b/backend/fsbackend/reference_test.go
@@ -18,7 +18,7 @@ func TestReference(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 		ref, err := b.Reference("refs/heads/doesnt_exists")
@@ -31,7 +31,7 @@ func TestReference(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 		ref, err := b.Reference(ginternals.HEAD)
@@ -49,7 +49,7 @@ func TestReference(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 		ref, err := b.Reference(gitpath.LocalBranch(ginternals.Master))
@@ -69,7 +69,7 @@ func TestParsePackedRefs(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(dir)
 		err := b.Init()
@@ -85,7 +85,7 @@ func TestParsePackedRefs(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(dir)
 		err := b.Init()
@@ -103,7 +103,7 @@ func TestParsePackedRefs(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(dir)
 		err := b.Init()
@@ -120,7 +120,7 @@ func TestParsePackedRefs(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 
@@ -146,7 +146,7 @@ func TestWriteReference(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(dir)
 		err := b.Init()
@@ -165,7 +165,7 @@ func TestWriteReference(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(dir)
 		err := b.Init()
@@ -186,7 +186,7 @@ func TestWriteReference(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(dir)
 		err := b.Init()
@@ -205,7 +205,7 @@ func TestWriteReference(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 
@@ -227,7 +227,7 @@ func TestWriteReference(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 
@@ -253,7 +253,7 @@ func TestWriteReferenceSafe(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(dir)
 		err := b.Init()
@@ -273,7 +273,7 @@ func TestWriteReferenceSafe(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(dir)
 		err := b.Init()
@@ -295,7 +295,7 @@ func TestWriteReferenceSafe(t *testing.T) {
 		t.Parallel()
 
 		dir, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(dir)
 		err := b.Init()
@@ -315,7 +315,7 @@ func TestWriteReferenceSafe(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 
@@ -339,7 +339,7 @@ func TestWriteReferenceSafe(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		b := New(filepath.Join(repoPath, gitpath.DotGitPath))
 

--- a/cmd/git-go/cat_file_test.go
+++ b/cmd/git-go/cat_file_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestCatFileParams(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		desc string
 		args []string
@@ -55,6 +57,8 @@ func TestCatFileParams(t *testing.T) {
 		tc := tc
 		i := i
 		t.Run(fmt.Sprintf("%d/%s", i, tc.desc), func(t *testing.T) {
+			t.Parallel()
+
 			cmd := newRootCmd()
 			cmd.SetArgs(tc.args)
 
@@ -68,6 +72,8 @@ func TestCatFileParams(t *testing.T) {
 }
 
 func TestCatFile(t *testing.T) {
+	t.Parallel()
+
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
 	t.Cleanup(cleanup)
 

--- a/cmd/git-go/cat_file_test.go
+++ b/cmd/git-go/cat_file_test.go
@@ -69,130 +69,128 @@ func TestCatFileParams(t *testing.T) {
 
 func TestCatFile(t *testing.T) {
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
-	t.Run("Parallel", func(t *testing.T) {
-		testCases := []struct {
-			desc           string
-			args           []string
-			expectedOutput string
-		}{
-			{
-				desc:           "-s should print the size (blob)",
-				args:           []string{"cat-file", "-s", "642480605b8b0fd464ab5762e044269cf29a60a3"},
-				expectedOutput: "453\n",
-			},
-			{
-				desc:           "-t should print the type (blob)",
-				args:           []string{"cat-file", "-t", "642480605b8b0fd464ab5762e044269cf29a60a3"},
-				expectedOutput: "blob\n",
-			},
-			{
-				desc:           "-p should pretty-print (blob)",
-				args:           []string{"cat-file", "-p", "642480605b8b0fd464ab5762e044269cf29a60a3"},
-				expectedOutput: "file://blob_642480605b8b0fd464ab5762e044269cf29a60a3",
-			},
-			{
-				desc:           "default should print raw object (blob)",
-				args:           []string{"cat-file", "blob", "642480605b8b0fd464ab5762e044269cf29a60a3"},
-				expectedOutput: "file://blob_642480605b8b0fd464ab5762e044269cf29a60a3",
-			},
-			{
-				desc:           "-s should print the size (tree)",
-				args:           []string{"cat-file", "-s", "e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"},
-				expectedOutput: "463\n",
-			},
-			{
-				desc:           "-t should print the type (tree)",
-				args:           []string{"cat-file", "-t", "e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"},
-				expectedOutput: "tree\n",
-			},
-			{
-				desc:           "-p should pretty-print (tree)",
-				args:           []string{"cat-file", "-p", "e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"},
-				expectedOutput: "file://tree_e5b9e846e1b468bc9597ff95d71dfacda8bd54e3_pretty",
-			},
-			{
-				desc:           "default should print raw object (tree)",
-				args:           []string{"cat-file", "tree", "e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"},
-				expectedOutput: "file://tree_e5b9e846e1b468bc9597ff95d71dfacda8bd54e3",
-			},
-			{
-				desc:           "-s should print the size (commit)",
-				args:           []string{"cat-file", "-s", "bbb720a96e4c29b9950a4c577c98470a4d5dd089"},
-				expectedOutput: "260\n",
-			},
-			{
-				desc:           "-t should print the type (commit)",
-				args:           []string{"cat-file", "-t", "bbb720a96e4c29b9950a4c577c98470a4d5dd089"},
-				expectedOutput: "commit\n",
-			},
-			{
-				desc:           "-p should pretty-print (commit)",
-				args:           []string{"cat-file", "-p", "bbb720a96e4c29b9950a4c577c98470a4d5dd089"},
-				expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
-			},
-			{
-				desc:           "default should print raw object (commit)",
-				args:           []string{"cat-file", "commit", "bbb720a96e4c29b9950a4c577c98470a4d5dd089"},
-				expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
-			},
-			{
-				desc:           "default should print raw object (annotated tag)",
-				args:           []string{"cat-file", "-p", "annotated"},
-				expectedOutput: "file://annotated",
-			},
-			{
-				desc:           "default should print raw object (HEAD)",
-				args:           []string{"cat-file", "-p", "HEAD"},
-				expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
-			},
-			{
-				desc:           "default should print raw object (refs/heads/ml/packfile/tests)",
-				args:           []string{"cat-file", "-p", "refs/heads/ml/packfile/tests"},
-				expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
-			},
-			{
-				desc:           "default should print raw object (heads/ml/packfile/tests)",
-				args:           []string{"cat-file", "-p", "heads/ml/packfile/tests"},
-				expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
-			},
-			{
-				desc:           "default should print raw object (ml/packfile/tests)",
-				args:           []string{"cat-file", "-p", "ml/packfile/tests"},
-				expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
-			},
-		}
-		for i, tc := range testCases {
-			tc := tc
-			i := i
-			t.Run(fmt.Sprintf("%d/%s", i, tc.desc), func(t *testing.T) {
-				t.Parallel()
+	testCases := []struct {
+		desc           string
+		args           []string
+		expectedOutput string
+	}{
+		{
+			desc:           "-s should print the size (blob)",
+			args:           []string{"cat-file", "-s", "642480605b8b0fd464ab5762e044269cf29a60a3"},
+			expectedOutput: "453\n",
+		},
+		{
+			desc:           "-t should print the type (blob)",
+			args:           []string{"cat-file", "-t", "642480605b8b0fd464ab5762e044269cf29a60a3"},
+			expectedOutput: "blob\n",
+		},
+		{
+			desc:           "-p should pretty-print (blob)",
+			args:           []string{"cat-file", "-p", "642480605b8b0fd464ab5762e044269cf29a60a3"},
+			expectedOutput: "file://blob_642480605b8b0fd464ab5762e044269cf29a60a3",
+		},
+		{
+			desc:           "default should print raw object (blob)",
+			args:           []string{"cat-file", "blob", "642480605b8b0fd464ab5762e044269cf29a60a3"},
+			expectedOutput: "file://blob_642480605b8b0fd464ab5762e044269cf29a60a3",
+		},
+		{
+			desc:           "-s should print the size (tree)",
+			args:           []string{"cat-file", "-s", "e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"},
+			expectedOutput: "463\n",
+		},
+		{
+			desc:           "-t should print the type (tree)",
+			args:           []string{"cat-file", "-t", "e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"},
+			expectedOutput: "tree\n",
+		},
+		{
+			desc:           "-p should pretty-print (tree)",
+			args:           []string{"cat-file", "-p", "e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"},
+			expectedOutput: "file://tree_e5b9e846e1b468bc9597ff95d71dfacda8bd54e3_pretty",
+		},
+		{
+			desc:           "default should print raw object (tree)",
+			args:           []string{"cat-file", "tree", "e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"},
+			expectedOutput: "file://tree_e5b9e846e1b468bc9597ff95d71dfacda8bd54e3",
+		},
+		{
+			desc:           "-s should print the size (commit)",
+			args:           []string{"cat-file", "-s", "bbb720a96e4c29b9950a4c577c98470a4d5dd089"},
+			expectedOutput: "260\n",
+		},
+		{
+			desc:           "-t should print the type (commit)",
+			args:           []string{"cat-file", "-t", "bbb720a96e4c29b9950a4c577c98470a4d5dd089"},
+			expectedOutput: "commit\n",
+		},
+		{
+			desc:           "-p should pretty-print (commit)",
+			args:           []string{"cat-file", "-p", "bbb720a96e4c29b9950a4c577c98470a4d5dd089"},
+			expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
+		},
+		{
+			desc:           "default should print raw object (commit)",
+			args:           []string{"cat-file", "commit", "bbb720a96e4c29b9950a4c577c98470a4d5dd089"},
+			expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
+		},
+		{
+			desc:           "default should print raw object (annotated tag)",
+			args:           []string{"cat-file", "-p", "annotated"},
+			expectedOutput: "file://annotated",
+		},
+		{
+			desc:           "default should print raw object (HEAD)",
+			args:           []string{"cat-file", "-p", "HEAD"},
+			expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
+		},
+		{
+			desc:           "default should print raw object (refs/heads/ml/packfile/tests)",
+			args:           []string{"cat-file", "-p", "refs/heads/ml/packfile/tests"},
+			expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
+		},
+		{
+			desc:           "default should print raw object (heads/ml/packfile/tests)",
+			args:           []string{"cat-file", "-p", "heads/ml/packfile/tests"},
+			expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
+		},
+		{
+			desc:           "default should print raw object (ml/packfile/tests)",
+			args:           []string{"cat-file", "-p", "ml/packfile/tests"},
+			expectedOutput: "file://commit_bbb720a96e4c29b9950a4c577c98470a4d5dd089",
+		},
+	}
+	for i, tc := range testCases {
+		tc := tc
+		i := i
+		t.Run(fmt.Sprintf("%d/%s", i, tc.desc), func(t *testing.T) {
+			t.Parallel()
 
-				outBuf := bytes.NewBufferString("")
-				cmd := newRootCmd()
-				cmd.SetOut(outBuf)
-				args := append([]string{"-C", repoPath}, tc.args...)
-				cmd.SetArgs(args)
+			outBuf := bytes.NewBufferString("")
+			cmd := newRootCmd()
+			cmd.SetOut(outBuf)
+			args := append([]string{"-C", repoPath}, tc.args...)
+			cmd.SetArgs(args)
 
-				var err error
-				require.NotPanics(t, func() {
-					err = cmd.Execute()
-				})
-				require.NoError(t, err)
-
-				out, err := ioutil.ReadAll(outBuf)
-				require.NoError(t, err)
-
-				expected := tc.expectedOutput
-				if strings.HasPrefix(tc.expectedOutput, "file://") {
-					filename := strings.TrimPrefix(tc.expectedOutput, "file://")
-					content, err := ioutil.ReadFile(filepath.Join(testhelper.TestdataPath(t), filename))
-					require.NoError(t, err)
-					expected = string(content)
-				}
-				assert.Equal(t, expected, string(out))
+			var err error
+			require.NotPanics(t, func() {
+				err = cmd.Execute()
 			})
-		}
-	})
+			require.NoError(t, err)
+
+			out, err := ioutil.ReadAll(outBuf)
+			require.NoError(t, err)
+
+			expected := tc.expectedOutput
+			if strings.HasPrefix(tc.expectedOutput, "file://") {
+				filename := strings.TrimPrefix(tc.expectedOutput, "file://")
+				content, err := ioutil.ReadFile(filepath.Join(testhelper.TestdataPath(t), filename))
+				require.NoError(t, err)
+				expected = string(content)
+			}
+			assert.Equal(t, expected, string(out))
+		})
+	}
 }

--- a/cmd/git-go/hash_object_test.go
+++ b/cmd/git-go/hash_object_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestHashObjectCmd(t *testing.T) {
+	t.Parallel()
+
 	t.Run("blob", func(t *testing.T) {
 		t.Parallel()
 

--- a/cmd/git-go/hash_object_test.go
+++ b/cmd/git-go/hash_object_test.go
@@ -19,7 +19,7 @@ func TestHashObjectCmd(t *testing.T) {
 			t.Parallel()
 
 			repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-			defer cleanup()
+			t.Cleanup(cleanup)
 
 			outBuf := bytes.NewBufferString("")
 			cmd := newRootCmd()

--- a/cmd/git-go/helpers_test.go
+++ b/cmd/git-go/helpers_test.go
@@ -10,46 +10,44 @@ import (
 
 func TestLoadRepository(t *testing.T) {
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
-	t.Run("Parallel", func(t *testing.T) {
-		testCases := []struct {
-			desc        string
-			C           string
-			expectError bool
-		}{
-			{
-				desc: "no path should use the current directory",
-				C:    "",
-			},
-			{
-				desc: "A given path should be used",
-				C:    repoPath,
-			},
-			{
-				desc:        "Invalid path should return an error",
-				C:           "/invalid/path",
-				expectError: true,
-			},
-		}
-		for i, tc := range testCases {
-			tc := tc
-			i := i
-			t.Run(fmt.Sprintf("%d/%s", i, tc.desc), func(t *testing.T) {
-				t.Parallel()
+	testCases := []struct {
+		desc        string
+		C           string
+		expectError bool
+	}{
+		{
+			desc: "no path should use the current directory",
+			C:    "",
+		},
+		{
+			desc: "A given path should be used",
+			C:    repoPath,
+		},
+		{
+			desc:        "Invalid path should return an error",
+			C:           "/invalid/path",
+			expectError: true,
+		},
+	}
+	for i, tc := range testCases {
+		tc := tc
+		i := i
+		t.Run(fmt.Sprintf("%d/%s", i, tc.desc), func(t *testing.T) {
+			t.Parallel()
 
-				cfg := &config{
-					C: tc.C,
-				}
-				repo, err := loadRepository(cfg)
-				if tc.expectError {
-					require.Error(t, err)
-					return
-				}
+			cfg := &config{
+				C: tc.C,
+			}
+			repo, err := loadRepository(cfg)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
 
-				require.NoError(t, err)
-				require.NotNil(t, repo)
-			})
-		}
-	})
+			require.NoError(t, err)
+			require.NotNil(t, repo)
+		})
+	}
 }

--- a/cmd/git-go/helpers_test.go
+++ b/cmd/git-go/helpers_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestLoadRepository(t *testing.T) {
+	t.Parallel()
+
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
 	t.Cleanup(cleanup)
 

--- a/ginternals/object/blob_test.go
+++ b/ginternals/object/blob_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestBlob(t *testing.T) {
+	t.Parallel()
+
 	t.Run("happy path", func(t *testing.T) {
 		t.Parallel()
 

--- a/ginternals/object/commit_test.go
+++ b/ginternals/object/commit_test.go
@@ -220,7 +220,7 @@ func TestCommitToObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 		r, err := git.OpenRepository(repoPath)
 		require.NoError(t, err)
 
@@ -258,7 +258,7 @@ func TestCommitToObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 		r, err := git.OpenRepository(repoPath)
 		require.NoError(t, err)
 

--- a/ginternals/object/commit_test.go
+++ b/ginternals/object/commit_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestSignatureString(t *testing.T) {
+	t.Parallel()
+
 	sig := object.NewSignature("John Doe", "john@domain.tld")
 	// for the sake of the test we gonna cheat a little bit and force
 	// the time to be UTC. Otherwise the test would not be consistent
@@ -26,6 +28,8 @@ func TestSignatureString(t *testing.T) {
 }
 
 func TestNewSignatureFromBytes(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		desc                 string
 		signature            string
@@ -118,6 +122,8 @@ func TestNewSignatureFromBytes(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
 			sig, err := object.NewSignatureFromBytes([]byte(tc.signature))
 			if tc.expectsError {
 				require.Error(t, err, "NewSignatureFromBytes should have failed")
@@ -135,6 +141,8 @@ func TestNewSignatureFromBytes(t *testing.T) {
 }
 
 func TestSignatureIsZero(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		desc   string
 		sig    object.Signature
@@ -178,6 +186,8 @@ func TestSignatureIsZero(t *testing.T) {
 }
 
 func TestNewCommit(t *testing.T) {
+	t.Parallel()
+
 	t.Run("NewCommit with all data sets", func(t *testing.T) {
 		t.Parallel()
 
@@ -216,6 +226,8 @@ func TestNewCommit(t *testing.T) {
 }
 
 func TestCommitToObject(t *testing.T) {
+	t.Parallel()
+
 	t.Run("duplicating a commit should work", func(t *testing.T) {
 		t.Parallel()
 

--- a/ginternals/object/object_test.go
+++ b/ginternals/object/object_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestAsCommit(t *testing.T) {
 	t.Parallel()
+
 	t.Run("regular commit with all the fields", func(t *testing.T) {
 		t.Parallel()
 
@@ -155,6 +156,8 @@ func TestAsBlob(t *testing.T) {
 }
 
 func TestType(t *testing.T) {
+	t.Parallel()
+
 	t.Run("type.String()", func(t *testing.T) {
 		t.Parallel()
 
@@ -368,6 +371,7 @@ func TestCompress(t *testing.T) {
 
 func TestAsTag(t *testing.T) {
 	t.Parallel()
+
 	t.Run("regular tag with all the fields", func(t *testing.T) {
 		t.Parallel()
 

--- a/ginternals/object/tag_test.go
+++ b/ginternals/object/tag_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestNewTag(t *testing.T) {
+	t.Parallel()
+
 	t.Run("NewTag with all data sets", func(t *testing.T) {
 		t.Parallel()
 
@@ -62,6 +64,8 @@ func TestNewTag(t *testing.T) {
 }
 
 func TestTagToObject(t *testing.T) {
+	t.Parallel()
+
 	t.Run("ToObject should return the raw object", func(t *testing.T) {
 		t.Parallel()
 

--- a/ginternals/object/tag_test.go
+++ b/ginternals/object/tag_test.go
@@ -18,7 +18,7 @@ func TestNewTag(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := git.OpenRepository(repoPath)
 		require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestTagToObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 		r, err := git.OpenRepository(repoPath)
 		require.NoError(t, err)
 
@@ -87,7 +87,7 @@ func TestTagToObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 		r, err := git.OpenRepository(repoPath)
 		require.NoError(t, err)
 		commitOid, err := ginternals.NewOidFromStr("bbb720a96e4c29b9950a4c577c98470a4d5dd089")

--- a/ginternals/object/tree_test.go
+++ b/ginternals/object/tree_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestTree(t *testing.T) {
+	t.Parallel()
+
 	t.Run("o.AsTree().ToObject() should return the same object", func(t *testing.T) {
 		t.Parallel()
 

--- a/ginternals/oid_test.go
+++ b/ginternals/oid_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestNewOidFromStr(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		desc          string
 		id            string
@@ -56,6 +58,8 @@ func TestNewOidFromStr(t *testing.T) {
 }
 
 func TestNewOidFromChars(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		desc          string
 		id            []byte
@@ -101,6 +105,8 @@ func TestNewOidFromChars(t *testing.T) {
 }
 
 func TestNewOidFromHex(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		desc          string
 		id            []byte
@@ -144,6 +150,8 @@ func TestNewOidFromHex(t *testing.T) {
 }
 
 func TestNewOidFromContent(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		desc       string
 		content    []byte
@@ -168,6 +176,8 @@ func TestNewOidFromContent(t *testing.T) {
 }
 
 func TestIsZero(t *testing.T) {
+	t.Parallel()
+
 	t.Run("from string", func(t *testing.T) {
 		t.Parallel()
 

--- a/ginternals/packfile/packfile_test.go
+++ b/ginternals/packfile/packfile_test.go
@@ -68,6 +68,8 @@ func TestGetObject(t *testing.T) {
 
 		// TODO(melvin): Test multiple parents
 		t.Run("commit", func(t *testing.T) {
+			t.Parallel()
+
 			commitOid, err := ginternals.NewOidFromStr("1dcdadc2a420225783794fbffd51e2e137a69646")
 			require.NoError(t, err)
 			o, err := pack.GetObject(commitOid)
@@ -94,6 +96,8 @@ func TestGetObject(t *testing.T) {
 		})
 
 		t.Run("blob", func(t *testing.T) {
+			t.Parallel()
+
 			blobOid, err := ginternals.NewOidFromStr("3f2f87160d5b4217125264310c22bcdad5b0d8bb")
 			require.NoError(t, err)
 			o, err := pack.GetObject(blobOid)
@@ -107,6 +111,8 @@ func TestGetObject(t *testing.T) {
 		})
 
 		t.Run("tree", func(t *testing.T) {
+			t.Parallel()
+
 			treeOid, err := ginternals.NewOidFromStr("c799e9129faae8d358e4b6de7813d6f970607893")
 			require.NoError(t, err)
 			o, err := pack.GetObject(treeOid)
@@ -130,6 +136,8 @@ func TestGetObject(t *testing.T) {
 		})
 
 		t.Run("tag", func(t *testing.T) {
+			t.Parallel()
+
 			t.Skip("tags not yet supported")
 		})
 	})

--- a/ginternals/packfile/packfile_test.go
+++ b/ginternals/packfile/packfile_test.go
@@ -21,23 +21,23 @@ func TestNewFromFile(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		packFileName := "pack-0163931160835b1de2f120e1aa7e52206debeb14.pack"
 		packFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPackPath, packFileName)
 		pack, err := packfile.NewFromFile(packFilePath)
 		require.NoError(t, err)
 		assert.NotNil(t, pack)
-		defer func() {
+		t.Cleanup(func() {
 			require.NoError(t, pack.Close())
-		}()
+		})
 	})
 
 	t.Run("indexfile should fail", func(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		packFileName := "pack-0163931160835b1de2f120e1aa7e52206debeb14.idx"
 		packFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPackPath, packFileName)
@@ -55,16 +55,16 @@ func TestGetObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		packFileName := "pack-0163931160835b1de2f120e1aa7e52206debeb14.pack"
 		packFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPackPath, packFileName)
 		pack, err := packfile.NewFromFile(packFilePath)
 		require.NoError(t, err)
 		assert.NotNil(t, pack)
-		defer func() {
+		t.Cleanup(func() {
 			require.NoError(t, pack.Close())
-		}()
+		})
 
 		// TODO(melvin): Test multiple parents
 		t.Run("commit", func(t *testing.T) {

--- a/ginternals/packfile/packindex_test.go
+++ b/ginternals/packfile/packindex_test.go
@@ -20,23 +20,23 @@ func TestNewIndexFromFile(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		indexFileName := "pack-0163931160835b1de2f120e1aa7e52206debeb14.idx"
 		indexFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPackPath, indexFileName)
 		index, err := packfile.NewIndexFromFile(indexFilePath)
 		require.NoError(t, err)
 		assert.NotNil(t, index)
-		defer func() {
+		t.Cleanup(func() {
 			require.NoError(t, index.Close())
-		}()
+		})
 	})
 
 	t.Run("a packfile should fail", func(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		indexFileName := "pack-0163931160835b1de2f120e1aa7e52206debeb14.pack"
 		indexFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPackPath, indexFileName)
@@ -52,16 +52,16 @@ func TestGetObjectOffset(t *testing.T) {
 
 	t.Run(string(testhelper.RepoSmall), func(t *testing.T) {
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		indexFileName := "pack-0163931160835b1de2f120e1aa7e52206debeb14.idx"
 		indexFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPackPath, indexFileName)
 		index, err := packfile.NewIndexFromFile(indexFilePath)
 		require.NoError(t, err)
 		assert.NotNil(t, index)
-		defer func() {
+		t.Cleanup(func() {
 			require.NoError(t, index.Close())
-		}()
+		})
 
 		t.Run("should work with valid oid", func(t *testing.T) {
 			oid, err := ginternals.NewOidFromStr("1dcdadc2a420225783794fbffd51e2e137a69646")

--- a/ginternals/packfile/packindex_test.go
+++ b/ginternals/packfile/packindex_test.go
@@ -51,6 +51,8 @@ func TestGetObjectOffset(t *testing.T) {
 	t.Parallel()
 
 	t.Run(string(testhelper.RepoSmall), func(t *testing.T) {
+		t.Parallel()
+
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
 		t.Cleanup(cleanup)
 
@@ -64,6 +66,8 @@ func TestGetObjectOffset(t *testing.T) {
 		})
 
 		t.Run("should work with valid oid", func(t *testing.T) {
+			t.Parallel()
+
 			oid, err := ginternals.NewOidFromStr("1dcdadc2a420225783794fbffd51e2e137a69646")
 			require.NoError(t, err)
 			offset, err := index.GetObjectOffset(oid)
@@ -72,6 +76,8 @@ func TestGetObjectOffset(t *testing.T) {
 		})
 
 		t.Run("should fail with invalid oid", func(t *testing.T) {
+			t.Parallel()
+
 			oid, err := ginternals.NewOidFromStr("1acdadc2a420225783794fbffd51e2e137a69646")
 			require.NoError(t, err)
 			_, err = index.GetObjectOffset(oid)

--- a/ginternals/reference_test.go
+++ b/ginternals/reference_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestIsRefNameValid(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		desc       string
 		name       string
@@ -140,6 +142,8 @@ func TestIsRefNameValid(t *testing.T) {
 }
 
 func TestResolveReference(t *testing.T) {
+	t.Parallel()
+
 	t.Run("should resolve oid reference", func(t *testing.T) {
 		t.Parallel()
 

--- a/repo_test.go
+++ b/repo_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestInit(t *testing.T) {
+	t.Parallel()
+
 	t.Run("repo with working tree", func(t *testing.T) {
 		t.Parallel()
 
@@ -56,6 +58,8 @@ func TestInit(t *testing.T) {
 }
 
 func TestOpen(t *testing.T) {
+	t.Parallel()
+
 	t.Run("repo with working tree", func(t *testing.T) {
 		t.Parallel()
 
@@ -141,6 +145,8 @@ func TestRepositoryGetObject(t *testing.T) {
 }
 
 func TestRepositoryNewBlob(t *testing.T) {
+	t.Parallel()
+
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
 	t.Cleanup(cleanup)
 
@@ -160,6 +166,8 @@ func TestRepositoryNewBlob(t *testing.T) {
 }
 
 func TestRepositoryGetCommit(t *testing.T) {
+	t.Parallel()
+
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
 	t.Cleanup(cleanup)
 
@@ -179,6 +187,8 @@ func TestRepositoryGetCommit(t *testing.T) {
 }
 
 func TestRepositoryGetReference(t *testing.T) {
+	t.Parallel()
+
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
 	t.Cleanup(cleanup)
 	r, err := OpenRepository(repoPath)
@@ -226,6 +236,8 @@ func TestRepositoryGetReference(t *testing.T) {
 }
 
 func TestRepositoryGetTree(t *testing.T) {
+	t.Parallel()
+
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
 	t.Cleanup(cleanup)
 
@@ -243,6 +255,8 @@ func TestRepositoryGetTree(t *testing.T) {
 }
 
 func TestRepositoryNewCommit(t *testing.T) {
+	t.Parallel()
+
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
 	t.Cleanup(cleanup)
 
@@ -276,6 +290,8 @@ func TestRepositoryNewCommit(t *testing.T) {
 }
 
 func TestRepositoryNewDetachedCommit(t *testing.T) {
+	t.Parallel()
+
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
 	t.Cleanup(cleanup)
 
@@ -309,6 +325,8 @@ func TestRepositoryNewDetachedCommit(t *testing.T) {
 }
 
 func TestRepositoryGetTag(t *testing.T) {
+	t.Parallel()
+
 	t.Run("annotated", func(t *testing.T) {
 		t.Parallel()
 
@@ -378,6 +396,8 @@ func TestRepositoryGetTag(t *testing.T) {
 }
 
 func TestRepositoryNewTag(t *testing.T) {
+	t.Parallel()
+
 	t.Run("create a new valid tag", func(t *testing.T) {
 		t.Parallel()
 
@@ -473,6 +493,8 @@ func TestRepositoryNewTag(t *testing.T) {
 }
 
 func TestRepositoryNewLightweightTag(t *testing.T) {
+	t.Parallel()
+
 	t.Run("create a new valid tag", func(t *testing.T) {
 		t.Parallel()
 

--- a/repo_test.go
+++ b/repo_test.go
@@ -21,7 +21,7 @@ func TestInit(t *testing.T) {
 
 		// Setup
 		d, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		// Run logic
 		r, err := InitRepository(d)
@@ -39,7 +39,7 @@ func TestInit(t *testing.T) {
 
 		// Setup
 		d, cleanup := testhelper.TempDir(t)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		// Run logic
 		r, err := InitRepositoryWithOptions(d, InitOptions{
@@ -60,7 +60,7 @@ func TestOpen(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err, "failed loading a repo")
@@ -77,7 +77,7 @@ func TestOpen(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 		repoPath = filepath.Join(repoPath, gitpath.DotGitPath)
 
 		r, err := OpenRepositoryWithOptions(repoPath, OpenOptions{
@@ -102,7 +102,7 @@ func TestRepositoryGetObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err, "failed loading a repo")
@@ -123,7 +123,7 @@ func TestRepositoryGetObject(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err, "failed loading a repo")
@@ -142,7 +142,7 @@ func TestRepositoryGetObject(t *testing.T) {
 
 func TestRepositoryNewBlob(t *testing.T) {
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	r, err := OpenRepository(repoPath)
 	require.NoError(t, err, "failed loading a repo")
@@ -161,7 +161,7 @@ func TestRepositoryNewBlob(t *testing.T) {
 
 func TestRepositoryGetCommit(t *testing.T) {
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	r, err := OpenRepository(repoPath)
 	require.NoError(t, err)
@@ -180,56 +180,54 @@ func TestRepositoryGetCommit(t *testing.T) {
 
 func TestRepositoryGetReference(t *testing.T) {
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	r, err := OpenRepository(repoPath)
 	require.NoError(t, err)
 
-	t.Run("Parallel", func(t *testing.T) {
-		testCases := []struct {
-			desc           string
-			refName        string
-			expectedError  error
-			expectedTarget string
-		}{
-			{
-				desc:           "HEAD should work",
-				refName:        "HEAD",
-				expectedTarget: "bbb720a96e4c29b9950a4c577c98470a4d5dd089",
-			},
-			{
-				desc:           "refs/heads/ml/packfile/tests should work",
-				refName:        "refs/heads/ml/packfile/tests",
-				expectedTarget: "bbb720a96e4c29b9950a4c577c98470a4d5dd089",
-			},
-			{
-				desc:          "an invalid name should fail",
-				refName:       "nope",
-				expectedError: ginternals.ErrRefNotFound,
-			},
-		}
-		for i, tc := range testCases {
-			tc := tc
-			i := i
-			t.Run(fmt.Sprintf("%d/%s", i, tc.desc), func(t *testing.T) {
-				t.Parallel()
+	testCases := []struct {
+		desc           string
+		refName        string
+		expectedError  error
+		expectedTarget string
+	}{
+		{
+			desc:           "HEAD should work",
+			refName:        "HEAD",
+			expectedTarget: "bbb720a96e4c29b9950a4c577c98470a4d5dd089",
+		},
+		{
+			desc:           "refs/heads/ml/packfile/tests should work",
+			refName:        "refs/heads/ml/packfile/tests",
+			expectedTarget: "bbb720a96e4c29b9950a4c577c98470a4d5dd089",
+		},
+		{
+			desc:          "an invalid name should fail",
+			refName:       "nope",
+			expectedError: ginternals.ErrRefNotFound,
+		},
+	}
+	for i, tc := range testCases {
+		tc := tc
+		i := i
+		t.Run(fmt.Sprintf("%d/%s", i, tc.desc), func(t *testing.T) {
+			t.Parallel()
 
-				ref, err := r.GetReference(tc.refName)
+			ref, err := r.GetReference(tc.refName)
 
-				if tc.expectedError != nil {
-					assert.True(t, errors.Is(err, tc.expectedError), "wrong error returned")
-					return
-				}
+			if tc.expectedError != nil {
+				assert.True(t, errors.Is(err, tc.expectedError), "wrong error returned")
+				return
+			}
 
-				require.NoError(t, err)
-				assert.Equal(t, tc.expectedTarget, ref.Target().String())
-			})
-		}
-	})
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedTarget, ref.Target().String())
+		})
+	}
 }
 
 func TestRepositoryGetTree(t *testing.T) {
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	r, err := OpenRepository(repoPath)
 	require.NoError(t, err)
@@ -246,7 +244,7 @@ func TestRepositoryGetTree(t *testing.T) {
 
 func TestRepositoryNewCommit(t *testing.T) {
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	r, err := OpenRepository(repoPath)
 	require.NoError(t, err)
@@ -279,7 +277,7 @@ func TestRepositoryNewCommit(t *testing.T) {
 
 func TestRepositoryNewDetachedCommit(t *testing.T) {
 	repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	r, err := OpenRepository(repoPath)
 	require.NoError(t, err)
@@ -315,7 +313,7 @@ func TestRepositoryGetTag(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err)
@@ -345,7 +343,7 @@ func TestRepositoryGetTag(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err)
@@ -368,7 +366,7 @@ func TestRepositoryGetTag(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err)
@@ -384,7 +382,7 @@ func TestRepositoryNewTag(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err)
@@ -427,7 +425,7 @@ func TestRepositoryNewTag(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err)
@@ -454,7 +452,7 @@ func TestRepositoryNewTag(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err)
@@ -479,7 +477,7 @@ func TestRepositoryNewLightweightTag(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err)
@@ -498,7 +496,7 @@ func TestRepositoryNewLightweightTag(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err)
@@ -516,7 +514,7 @@ func TestRepositoryNewLightweightTag(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err)

--- a/tree_builder_test.go
+++ b/tree_builder_test.go
@@ -50,7 +50,7 @@ func TestTreeBuilderInsert(t *testing.T) {
 				t.Parallel()
 
 				repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-				defer cleanup()
+				t.Cleanup(cleanup)
 
 				r, err := OpenRepository(repoPath)
 				require.NoError(t, err, "failed loading a repo")
@@ -76,7 +76,7 @@ func TestTreeBuilderInsert(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err, "failed loading a repo")
@@ -103,7 +103,7 @@ func TestTreeBuilderInsert(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err, "failed loading a repo")
@@ -133,7 +133,7 @@ func TestTreeBuilderInsert(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err, "failed loading a repo")
@@ -154,7 +154,7 @@ func TestTreeBuilderRemove(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err, "failed loading a repo")
@@ -188,7 +188,7 @@ func TestTreeBuilderRemove(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err, "failed loading a repo")
@@ -213,7 +213,7 @@ func TestTreeBuilderWrite(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err, "failed loading a repo")
@@ -230,7 +230,7 @@ func TestTreeBuilderWrite(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err, "failed loading a repo")
@@ -263,7 +263,7 @@ func TestTreeBuilderWrite(t *testing.T) {
 		t.Parallel()
 
 		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
-		defer cleanup()
+		t.Cleanup(cleanup)
 
 		r, err := OpenRepository(repoPath)
 		require.NoError(t, err, "failed loading a repo")

--- a/tree_builder_test.go
+++ b/tree_builder_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestTreeBuilderInsert(t *testing.T) {
+	t.Parallel()
+
 	t.Run("single pass/fail", func(t *testing.T) {
 		t.Parallel()
 
@@ -150,6 +152,8 @@ func TestTreeBuilderInsert(t *testing.T) {
 }
 
 func TestTreeBuilderRemove(t *testing.T) {
+	t.Parallel()
+
 	t.Run("should remove elements", func(t *testing.T) {
 		t.Parallel()
 
@@ -209,6 +213,8 @@ func TestTreeBuilderRemove(t *testing.T) {
 }
 
 func TestTreeBuilderWrite(t *testing.T) {
+	t.Parallel()
+
 	t.Run("should return 4b825dc642cb6eb9a060e54bf8d69288fbee4904 for empty tree", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
`defer` has bad side-effects that required some hacks. the proper way is to clean up using `t.Cleanup()`. This PR also fixes/normalize the usage of `t.Parallel()`