### PR TITLE
ci: Update golangci-lint and its action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.30
+          version: v1.33
 
   build:
     name: Build


### PR DESCRIPTION
golangci-lint upgraded to 1.33
action upgraded to 2.x