### PR TITLE
ci: update dependabot run time + ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,19 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      day: "friday"
+      time: "16:00"
+      timezone: "America/Los_Angeles"
+    assignees:
+      - "Nivl"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      day: "friday"
+      time: "16:00"
+      timezone: "America/Los_Angeles"
+    assignees:
+      - "Nivl"


### PR DESCRIPTION
Add `github-actions` and run the tool on Fridays at 4pm Pacific time