### PR TITLE
ci: fix codeql syntax

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, * ]
+    branches: [ master ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]


### PR DESCRIPTION
It seems that the default codeql config file generated by github was invalid