### PR TITLE
test: fix flaky tests caused in TestGetObject

### DIFF
--- a/ginternals/packfile/packfile_test.go
+++ b/ginternals/packfile/packfile_test.go
@@ -68,8 +68,6 @@ func TestGetObject(t *testing.T) {
 
 		// TODO(melvin): Test multiple parents
 		t.Run("commit", func(t *testing.T) {
-			t.Parallel()
-
 			commitOid, err := ginternals.NewOidFromStr("1dcdadc2a420225783794fbffd51e2e137a69646")
 			require.NoError(t, err)
 			o, err := pack.GetObject(commitOid)
@@ -96,8 +94,6 @@ func TestGetObject(t *testing.T) {
 		})
 
 		t.Run("blob", func(t *testing.T) {
-			t.Parallel()
-
 			blobOid, err := ginternals.NewOidFromStr("3f2f87160d5b4217125264310c22bcdad5b0d8bb")
 			require.NoError(t, err)
 			o, err := pack.GetObject(blobOid)
@@ -111,8 +107,6 @@ func TestGetObject(t *testing.T) {
 		})
 
 		t.Run("tree", func(t *testing.T) {
-			t.Parallel()
-
 			treeOid, err := ginternals.NewOidFromStr("c799e9129faae8d358e4b6de7813d6f970607893")
 			require.NoError(t, err)
 			o, err := pack.GetObject(treeOid)
@@ -136,8 +130,6 @@ func TestGetObject(t *testing.T) {
 		})
 
 		t.Run("tag", func(t *testing.T) {
-			t.Parallel()
-
 			// TODO(melvin): we now support tags
 			t.Skip("tags not yet supported")
 		})


### PR DESCRIPTION
Fixes #62

Regression from 13dd942. The packfile and the indexfile structs are not go-routine safe.