### PR TITLE
refactor(packfile): improve parsing and async operations

### DIFF
--- a/backend/fsbackend/reference.go
+++ b/backend/fsbackend/reference.go
@@ -60,7 +60,7 @@ func (b *Backend) systemPath(name string) string {
 // https://git-scm.com/docs/git-pack-refs
 func (b *Backend) parsePackedRefs() (refs map[string]string, err error) {
 	refs = map[string]string{}
-	f, err := os.Open(filepath.Join(b.root, gitpath.PackedRefsPath))
+	f, err := b.fs.Open(filepath.Join(b.root, gitpath.PackedRefsPath))
 	if err != nil {
 		// if the file doesn't exist we just return an empty map
 		if os.IsNotExist(err) {
@@ -131,7 +131,7 @@ func (b *Backend) WriteReferenceSafe(ref *ginternals.Reference) error {
 
 	// First we check if the reference is on disk
 	p := b.systemPath(ref.Name())
-	_, err := os.Stat(p)
+	_, err := b.fs.Stat(p)
 	if !os.IsNotExist(err) {
 		if err != nil {
 			return xerrors.Errorf("could not check if reference exists on disk: %w", err)

--- a/ginternals/packfile/packfile_test.go
+++ b/ginternals/packfile/packfile_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Nivl/git-go/ginternals/packfile"
 	"github.com/Nivl/git-go/internal/gitpath"
 	"github.com/Nivl/git-go/internal/testhelper"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
@@ -25,7 +26,7 @@ func TestNewFromFile(t *testing.T) {
 
 		packFileName := "pack-0163931160835b1de2f120e1aa7e52206debeb14.pack"
 		packFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPackPath, packFileName)
-		pack, err := packfile.NewFromFile(packFilePath)
+		pack, err := packfile.NewFromFile(afero.NewOsFs(), packFilePath)
 		require.NoError(t, err)
 		assert.NotNil(t, pack)
 		t.Cleanup(func() {
@@ -41,7 +42,7 @@ func TestNewFromFile(t *testing.T) {
 
 		packFileName := "pack-0163931160835b1de2f120e1aa7e52206debeb14.idx"
 		packFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPackPath, packFileName)
-		pack, err := packfile.NewFromFile(packFilePath)
+		pack, err := packfile.NewFromFile(afero.NewOsFs(), packFilePath)
 		require.Error(t, err)
 		assert.True(t, xerrors.Is(err, packfile.ErrInvalidMagic))
 		assert.Nil(t, pack)
@@ -59,7 +60,7 @@ func TestGetObject(t *testing.T) {
 
 		packFileName := "pack-0163931160835b1de2f120e1aa7e52206debeb14.pack"
 		packFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPackPath, packFileName)
-		pack, err := packfile.NewFromFile(packFilePath)
+		pack, err := packfile.NewFromFile(afero.NewOsFs(), packFilePath)
 		require.NoError(t, err)
 		assert.NotNil(t, pack)
 		t.Cleanup(func() {
@@ -148,14 +149,14 @@ func TestObjectCount(t *testing.T) {
 		// Load the packfile
 		packFileName := "pack-0163931160835b1de2f120e1aa7e52206debeb14.pack"
 		packFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPackPath, packFileName)
-		pack, err := packfile.NewFromFile(packFilePath)
+		pack, err := packfile.NewFromFile(afero.NewOsFs(), packFilePath)
 		require.NoError(t, err)
 		assert.NotNil(t, pack)
 		t.Cleanup(func() {
 			require.NoError(t, pack.Close())
 		})
 
-		// TODO(melvin): this will break each time we change update
+		// TODO(melvin): this will break each time we update
 		// the test repo.
 		// This needs to be rewritten once we have a way to create packfile
 		assert.Equal(t, uint32(364), pack.ObjectCount())
@@ -171,14 +172,14 @@ func TestID(t *testing.T) {
 	// Load the packfile
 	packFileName := "pack-0163931160835b1de2f120e1aa7e52206debeb14.pack"
 	packFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPackPath, packFileName)
-	pack, err := packfile.NewFromFile(packFilePath)
+	pack, err := packfile.NewFromFile(afero.NewOsFs(), packFilePath)
 	require.NoError(t, err)
 	assert.NotNil(t, pack)
 	t.Cleanup(func() {
 		require.NoError(t, pack.Close())
 	})
 
-	// TODO(melvin): this will break each time we change update
+	// TODO(melvin): this will break each time we update
 	// the test repo.
 	// This needs to be rewritten once we have a way to create packfile
 	oid, err := pack.ID()

--- a/ginternals/packfile/packindex.go
+++ b/ginternals/packfile/packindex.go
@@ -3,10 +3,12 @@ package packfile
 import (
 	"bytes"
 	"encoding/binary"
-	"os"
+	"io"
 	"sort"
+	"sync"
 
 	"github.com/Nivl/git-go/ginternals"
+	"github.com/Nivl/git-go/internal/readutil"
 	"golang.org/x/xerrors"
 )
 
@@ -15,12 +17,12 @@ const (
 	layer2EntrySize = ginternals.OidSize
 	layer3EntrySize = 4
 	layer4EntrySize = 4
-	layer5EntrySize = 8
 )
 
 // indexHeader represents the header of an index file.
 // the first 4 bytes contain the magic, the 4 next bytes
-// contains the version of the file
+// contains the version of the file.
+// We only support Version 2
 func indexHeader() []byte {
 	return []byte{255, 't', 'O', 'c', 0, 0, 0, 2}
 }
@@ -41,7 +43,7 @@ func indexHeader() []byte {
 //         is equal to '9b' which corresponds to 155.
 //         You'll then find the CUMULATIVE object count at the
 //         position 155 * 4 in layer1.
-//         To get the total of object stating with 9b, you will need
+//         To get the total of object starting with 9b, you will need
 //         to look at the previous entry (9a at 154 * 4), and do
 //         total_at_9b = cumul_9b - cummul_9a
 // Layer2: x*20 bytes - Contains the IDs (20 Bytes each) of all the objects
@@ -81,26 +83,20 @@ func indexHeader() []byte {
 // https://codewords.recurse.com/issues/three/unpacking-git-packfiles#idx-files
 // https://git-scm.com/docs/pack-format
 type PackIndex struct {
-	r *os.File
+	r          readutil.BufferedReader
+	hashOffset map[ginternals.Oid]uint64
+
+	parsed     bool
+	parseError error
+
+	mu sync.Mutex
 }
 
-// NewIndexFromFile returns an index object from the given file
-// The index will need to be closed using Close()
-func NewIndexFromFile(filePath string) (idx *PackIndex, err error) {
-	f, err := os.Open(filePath)
-	if err != nil {
-		return nil, xerrors.Errorf("could not open %s: %w", filePath, err)
-	}
-
-	defer func() {
-		if err != nil {
-			f.Close() //nolint:errcheck // it already failed
-		}
-	}()
-
+// NewIndex returns an index object from the given reader
+func NewIndex(r readutil.BufferedReader) (idx *PackIndex, err error) {
 	// Let's validate the header
 	header := make([]byte, len(indexHeader()))
-	_, err = f.Read(header)
+	_, err = r.Read(header)
 	if err != nil {
 		return nil, xerrors.Errorf("could read header of index file: %w", err)
 	}
@@ -109,203 +105,187 @@ func NewIndexFromFile(filePath string) (idx *PackIndex, err error) {
 	}
 
 	return &PackIndex{
-		r: f,
+		r: r,
 	}, nil
 }
 
-// Close frees the resources
-func (idx *PackIndex) Close() error {
-	return idx.r.Close()
-}
-
 // GetObjectOffset returns the offset of Oid in the packfile
-// If the object is not found ErrObjectNotFound is returned
-//
-// The way this works is:
-// - First we need to check layer1 to get data about how many
-//   objects are stored in the packfile.
-// - Then we need to look up in layer 2 for the index of the oid we're
-//   working on.
-// - Then we can look in layer 4 for the object's offset
-// - If the packfile is too big (> 2GB), we might need to look in layer5
-//   For the actual offset, because layer4 only store int32 offsets
-//   while layer5 stores int64 offsets
+// If the object is not found ginternals.ErrObjectNotFound is returned
 func (idx *PackIndex) GetObjectOffset(oid ginternals.Oid) (uint64, error) {
-	// First we need to check how many objects in the packfile start by
-	// oid[0], how many objects are between 0x00 and oid[0] (cumul), and
-	// how many objects are in the packfile
-	objCount, cumul, totalObjects, err := idx.ObjectCountAt(oid[0])
-	if err != nil {
-		return 0, xerrors.Errorf("could not get object count: %w", err)
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	if !idx.parsed {
+		if err := idx.parse(); err != nil {
+			return 0, xerrors.Errorf("could not parse the index file: %w", err)
+		}
 	}
-	if objCount == 0 {
+	offset, exists := idx.hashOffset[oid]
+	if !exists {
 		return 0, ginternals.ErrObjectNotFound
 	}
-
-	// Now that we have the cumul, the count and the total, we can
-	// find the index of our oid in layer2.
-	// Because the data are always ordered in the same way in every layers
-	// the index will be use to retrieve the data in the other layer.
-	// For example, if our oid is the 3rd in layer2, it will also be the
-	// 3rd in layer3 and layer4.
-	oidIdx, err := idx.index(oid, objCount, cumul)
-	if err != nil {
-		return 0, xerrors.Errorf("could not find oid index: %w", err)
-	}
-
-	// Now we can lookup in layer4 for the object's offset in the packfile
-	layer2offset := len(indexHeader()) + layer1Size
-	layer2Size := int64(totalObjects) * int64(layer2EntrySize)
-	layer3Size := int64(totalObjects) * int64(layer3EntrySize)
-	layer4Offset := int64(layer2offset) + layer2Size + layer3Size
-	entryOffset := layer4Offset + int64(oidIdx*layer4EntrySize)
-
-	// Now we can just get the layer4 entry that contains the offset
-	entryValue := make([]byte, layer4EntrySize)
-	_, err = idx.r.ReadAt(entryValue, entryOffset)
-	if err != nil {
-		return 0, xerrors.Errorf("could not read object offset in layer4 at offset %d: %w", entryOffset, err)
-	}
-	entry := binary.BigEndian.Uint32(entryValue)
-
-	// The entry contains 2 information, a MSB and the offset.
-	// The MSB correspond to the first bit on the very left, and the
-	// offset is stored in the 31 next bits (because its a 32bits number)
-
-	// One way to get the MSB value is to push it 31 bits to the right.
-	// If the MSB is one, then our 32bits number will now be
-	// 00000000000000000000000000000001, which is the binary
-	// representation of 1
-	// If the MSB is 0, then all the bits will be set to 0, which is
-	// the binary representation of a 0.
-	msb := (entry >> 31) == 1
-
-	// Now to get the offset we need to force the MSB to be 0.
-	// To do so we can use a binary mask with a AND. We use 0 for the
-	// bits we want to change to 0, and 1 for the bits we want to stay at
-	// their current value.
-	offset := entry & 0b01111111111111111111111111111111
-	// if the msb is not set, then the offset is valid, and we're done
-	if !msb {
-		return uint64(offset), nil
-	}
-
-	// If the msb is set, then the offset we got is to get an entry in layer5,
-	// which will contain the offset in the packfile
-	layer4Size := int64(totalObjects) + int64(layer4EntrySize)
-	layer5Offset := layer4Offset + layer4Size
-	entryOffset = layer5Offset + int64(offset)
-
-	entryValue = make([]byte, layer5EntrySize)
-	_, err = idx.r.ReadAt(entryValue, entryOffset)
-	if err != nil {
-		return 0, xerrors.Errorf("could not read object offset in layer5 at offset %d: %w", entryOffset, err)
-	}
-	finalOffset := binary.BigEndian.Uint64(entryValue)
-
-	return finalOffset, nil
+	return offset, nil
 }
 
-// ObjectCountAt searches in layer1 the number of objects starting
-// with the given prefix.
-// Returns the number of objects at prefix, the cumulative number
-// of objects we have at this prefix, and the total amount of object
-// the packfile has.
-//
-// The prefix corresponds of the 2 first chars of a SHA (similar to what
-// you can find in .git/objects for loose objects).
-// Because the count is cumulative, to know how many items there is for
-// 0x88 (for example), we need to compare it with the count of 0x87
-// Ex. For the object fde92e904ca4678cdf23e72582c27a50c310d96d
-// the prefix is "0xfd", and the count will be "${count at fd} - ${count at fc}"
-func (idx *PackIndex) ObjectCountAt(prefix byte) (count, cumul, total uint32, err error) {
-	layer1Offset := len(indexHeader())
-	entrySize := 4
-	entry := make([]byte, 4)
+// parse extracts all the data from the index and puts them in memory.
+func (idx *PackIndex) parse() (err error) {
+	// No reason to call this method more than once
+	if idx.parsed {
+		return nil
+	}
 
-	// First we get the total of objects in the packfile
-	lastEntryOffset := 255 * entrySize
-	_, err = idx.r.ReadAt(entry, int64(layer1Offset+lastEntryOffset))
+	// If the method failed, then there's no reason to try again,
+	// especially that the underlying reader doesn't get its cursor
+	// reset
+	if idx.parseError != nil {
+		return idx.parseError
+	}
+	defer func() {
+		if err != nil {
+			idx.parseError = err
+		}
+	}()
+
+	bufInt32 := make([]byte, 4)
+	bufInt64 := make([]byte, 8)
+	bufOid := make([]byte, ginternals.OidSize)
+
+	// First we parse layer1 to get the count of objects in the packfile.
+	// Since layer1 stores a cumul, all we have to do is to get the number
+	// at the last position, which is at 0xff (or 255). See doc for
+	// more details
+	lastEntryRelOffset := 255 * 4 // an entry is an int32, so 4 bytes
+	// We move the pointer to the data we need
+	_, err = idx.r.Discard(lastEntryRelOffset)
 	if err != nil {
-		return 0, 0, 0, xerrors.Errorf("couldn't get the total number of objects: %w", err)
+		return xerrors.Errorf("could not move pointer to the last entry of layer1: %w", err)
 	}
-	total = binary.BigEndian.Uint32(entry)
-
-	prevPrefix := prefix - 1
-	// If we're trying to get the count at position 0, then there's
-	// nothing before, so we make sure not to have a negative "previous"
-	if prefix == 0 {
-		prevPrefix = 0
-	}
-
-	offset := int64(layer1Offset + int(prevPrefix)*entrySize)
-	_, err = idx.r.ReadAt(entry, offset)
+	// we now can read the count
+	_, err = io.ReadFull(idx.r, bufInt32)
 	if err != nil {
-		return 0, 0, 0, xerrors.Errorf("couldn't read previous entry at pos %d: %w", offset, err)
+		return xerrors.Errorf("couldn't get the total number of objects: %w", err)
 	}
-	prevCumul := binary.BigEndian.Uint32(entry)
+	objectCount := int(binary.BigEndian.Uint32(bufInt32))
 
-	// If we want the count a position 0, then the cumul and the count
-	// are the same
-	if prefix == 0 {
-		count = prevCumul
-		cumul = prevCumul
-		return count, cumul, total, nil
-	}
-
-	// If we want the count for the last position, we already have the total
-	// which is also our cumul
-	if prefix == 255 {
-		count = total - prevCumul
-		cumul = total
-		return count, cumul, total, nil
-	}
-
-	// otherwise we just move to the next entry, and read it
-	offset += int64(entrySize)
-	_, err = idx.r.ReadAt(entry, offset)
-	if err != nil {
-		return 0, 0, 0, xerrors.Errorf("couldn't read current entry at pos %d: %w", offset, err)
-	}
-	cumul = binary.BigEndian.Uint32(entry)
-	count = cumul - prevCumul
-	return count, cumul, total, nil
-}
-
-// index searches for the index of $oid in layer2.
-// $oidCount represents the number of oids at oid[0]
-// $oidCumul represents the number of oids from 0x00 to oid[0]
-func (idx *PackIndex) index(oid ginternals.Oid, oidCount, oidCumul uint32) (int, error) {
-	// layer2offset corresponds to the beginning of layer2 in the file
+	// Now we can allocate the right amount of memory to store all the
+	// oids temporarily in an ordered list, and fill it by parsing
+	// layer2 which contains all oids back-to-back
+	oids := make([]ginternals.Oid, 0, objectCount)
+	// we basically need to get everything in between layer2 and
+	// layer3
 	layer2offset := len(indexHeader()) + layer1Size
-	// First index corresponds to the index of the first oid starting by
-	// oid[0]
-	firstOidIndex := int(oidCumul - oidCount)
-	// listOffset correspond to the beginning of the list of the oids
-	// starting by oid[0] in Layer2
-	listOffset := firstOidIndex * layer2EntrySize
+	layer2Size := objectCount * layer2EntrySize
+	layer3offset := layer2offset + layer2Size
 
-	// Now we grab all the oids that start by oid[0].
-	oidRange := make([]byte, oidCount*ginternals.OidSize)
-	rangeOffset := int64(layer2offset + listOffset)
-	_, err := idx.r.ReadAt(oidRange, rangeOffset)
+	for i := 0; i < objectCount; i++ {
+		currentOffset := layer2offset + i*ginternals.OidSize
+		// this should only happen if the indexfile is invalid and
+		// layer2 is smaller than it should
+		if currentOffset >= layer3offset {
+			return xerrors.Errorf("oid %d is out of bound in layer2", i)
+		}
+
+		_, err = io.ReadFull(idx.r, bufOid)
+		if err != nil {
+			return xerrors.Errorf("couldn't get the oid at offset %d: %w", currentOffset, err)
+		}
+		oid, err := ginternals.NewOidFromHex(bufOid)
+		if err != nil {
+			return xerrors.Errorf("invalid oid at offset %d: %w", currentOffset, err)
+		}
+		oids = append(oids, oid)
+	}
+
+	// We don't care about layer3 just yet so we skip it
+	// TODO(melvin): parse and use layer3
+	layer3Size := objectCount * layer3EntrySize
+	_, err = idx.r.Discard(layer3Size)
 	if err != nil {
-		return 0, xerrors.Errorf("could not read %d oids in layer2 at offset %d: %w", oidCount, rangeOffset, err)
+		return xerrors.Errorf("could not skip layer3: %w", err)
 	}
 
-	// The next step is to do a binary search to find our oid in the list
-	// (that's much faster than looping around everything on big packfile)
-	oidIdxRel := sort.Search(int(oidCount), func(i int) bool {
-		start := i * ginternals.OidSize
-		currentOid := oidRange[start : start+ginternals.OidSize]
-		return bytes.Compare(oid.Bytes(), currentOid) <= 0
-	})
+	// We can now allocate our final map (oid => offset) and fill it with the
+	// correct offsets by reading into layer4 and layer5
+	// We'll first loop over layer4, then into layer if needed
+	idx.hashOffset = make(map[ginternals.Oid]uint64, objectCount)
+	layer4Offset := layer2offset + layer2Size + layer3Size
+	layer4Size := objectCount * layer4EntrySize
+	layer5Offset := int64(layer4Offset + layer4Size)
 
-	// We need to make sure we found our oid
-	start := oidIdxRel * ginternals.OidSize
-	if oidIdxRel >= int(oidCount) || !bytes.Equal(oid.Bytes(), oidRange[start:start+ginternals.OidSize]) {
-		return 0, ginternals.ErrObjectNotFound
+	// Before fetching the data in layer 4, we need to make a list to
+	// store the object that we'll need to find in layer5. Because we use
+	// a buffered reader, we cannot go back and forth between layer4 and 5,
+	// so if layer4 contains a layer5 object, we'll have to read it later
+	type layer5Data struct {
+		oid            ginternals.Oid
+		relativeOffset uint64
+	}
+	layer5offsets := []*layer5Data{}
+
+	// now we can start parsing layer4
+	for i, oid := range oids {
+		currentOffset := int64(layer4Offset + i*layer4EntrySize)
+		// this should only happen if the indexfile is invalid and
+		// layer4 is smaller than it should
+		if currentOffset >= layer5Offset {
+			return xerrors.Errorf("oid %s is out of bound in layer4", oid.String())
+		}
+		_, err = io.ReadFull(idx.r, bufInt32)
+		if err != nil {
+			return xerrors.Errorf("couldn't read offset of oid %s at position %d (layer4): %w", oid.String(), currentOffset, err)
+		}
+		entry := binary.BigEndian.Uint32(bufInt32)
+
+		// The entry contains 2 information, a MSB and the offset.
+		// The MSB correspond to the first bit on the very left, and the
+		// offset is stored in the 31 next bits (because its a 32bits number)
+
+		// One way to get the MSB value is to push it 31 bits to the right.
+		// If the MSB is one, then our 32bits number will now be
+		// 00000000000000000000000000000001, which is the binary
+		// representation of 1
+		// If the MSB is 0, then all the bits will be set to 0, which is
+		// the binary representation of a 0.
+		msb := (entry >> 31) == 1
+
+		// Now to get the offset we need to force the MSB to be 0.
+		// To do so we can use a binary mask with a AND. We use 0 for the
+		// bits we want to change to 0, and 1 for the bits we want to stay at
+		// their current value.
+		offset := uint64(entry & 0b01111111111111111111111111111111)
+		// If the msb is not set, then the offset is valid, and we're done.
+		// If the msb is set then the offset we got is to get an entry in
+		// layer5, which will contain the offset in the packfile
+		if msb {
+			layer5offsets = append(layer5offsets, &layer5Data{
+				oid:            oid,
+				relativeOffset: offset,
+			})
+			continue
+		}
+		idx.hashOffset[oid] = offset
 	}
 
-	return firstOidIndex + oidIdxRel, nil
+	// Now we go get the offset from layer5
+	// We need to make sure we access the offset in the right order
+	// since we won't be able to go back to a lower offset
+	sort.Slice(layer5offsets, func(i, j int) bool { return layer5offsets[i].relativeOffset < layer5offsets[j].relativeOffset })
+	currentRelativeOffset := uint64(0)
+	for _, data := range layer5offsets {
+		// This should never happen since the offsert should be back-
+		// to-back, but it cost nothing to double check
+		if data.relativeOffset != currentRelativeOffset {
+			return xerrors.Errorf("expected oid %s to be at (relative) offset %d, but is at %d instead (in layer5 %d)", data.oid.String(), currentRelativeOffset, data.relativeOffset, layer5Offset)
+		}
+
+		entryOffset := layer5Offset + int64(data.relativeOffset)
+		_, err = io.ReadFull(idx.r, bufInt64)
+		if err != nil {
+			return xerrors.Errorf("couldn't read offset of oid %s at position %d (layer5): %w", data.oid.String(), entryOffset, err)
+		}
+		offset := binary.BigEndian.Uint64(bufInt64)
+		idx.hashOffset[data.oid] = offset
+	}
+	idx.parsed = true
+	return nil
 }

--- a/internal/readutil/buffered_reader.go
+++ b/internal/readutil/buffered_reader.go
@@ -1,0 +1,8 @@
+package readutil
+
+// BufferedReader is an interface that represents a reader with an
+// internal buffer.
+type BufferedReader interface {
+	Discard(n int) (discarded int, err error)
+	Read(p []byte) (n int, err error)
+}


### PR DESCRIPTION
The goal here is to refactor the packfile code (and its index) to make them more optimized and reusable (dump as much data as it is safely possible in memory, prevent overusing syscalls, reuse buffers, etc.). A repo should then keep reusing the same packfile / index instances.

TODO:
- [x] Make packfile readable async
- [x] Have packfile take a reader, or an afero object
- [x] Take care of all in-code TODOs  
- [x] Update index tests
- [x] Update packfile tests