### PR TITLE
refactor: use errutil.Close() instead of a function literal

### DIFF
--- a/backend/fsbackend/reference.go
+++ b/backend/fsbackend/reference.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Nivl/git-go/ginternals"
+	"github.com/Nivl/git-go/internal/errutil"
 	"github.com/Nivl/git-go/internal/gitpath"
 	"golang.org/x/xerrors"
 )
@@ -68,12 +69,7 @@ func (b *Backend) parsePackedRefs() (refs map[string]string, err error) {
 		}
 		return nil, xerrors.Errorf("could not open %s: %w", gitpath.PackedRefsPath, err)
 	}
-	defer func() {
-		closeErr := f.Close()
-		if err == nil {
-			err = closeErr
-		}
-	}()
+	defer errutil.Close(f, &err)
 
 	sc := bufio.NewScanner(f)
 	for i := 1; sc.Scan(); i++ {

--- a/ginternals/object/object.go
+++ b/ginternals/object/object.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/Nivl/git-go/ginternals"
+	"github.com/Nivl/git-go/internal/errutil"
 	"github.com/Nivl/git-go/internal/readutil"
 	"golang.org/x/xerrors"
 )
@@ -188,17 +189,10 @@ func (o *Object) Compress() (data []byte, err error) {
 	o.id = newID
 	compressedContent := new(bytes.Buffer)
 	zw := zlib.NewWriter(compressedContent)
-	defer func() {
-		closeErr := zw.Close()
-		if err == nil {
-			err = closeErr
-		}
-	}()
+	defer errutil.Close(zw, &err)
+
 	if _, err = zw.Write(fileContent); err != nil {
 		return nil, xerrors.Errorf("could not zlib the object: %w", err)
-	}
-	if err = zw.Close(); err != nil {
-		return nil, xerrors.Errorf("could not close the compressor: %w", err)
 	}
 	return compressedContent.Bytes(), nil
 }

--- a/ginternals/packfile/packfile.go
+++ b/ginternals/packfile/packfile.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Nivl/git-go/ginternals"
 	"github.com/Nivl/git-go/ginternals/object"
+	"github.com/Nivl/git-go/internal/errutil"
 	"github.com/spf13/afero"
 	"golang.org/x/xerrors"
 )
@@ -276,12 +277,7 @@ func (pck *Pack) getRawObjectAt(oid ginternals.Oid, objectOffset uint64) (o *obj
 	if err != nil {
 		return nil, ginternals.NullOid, 0, xerrors.Errorf("could not get zlib reader: %w", err)
 	}
-	defer func() {
-		closeErr := zlibR.Close()
-		if err == nil {
-			err = closeErr
-		}
-	}()
+	defer errutil.Close(zlibR, &err)
 
 	objectData := bytes.Buffer{}
 	_, err = io.Copy(&objectData, zlibR)


### PR DESCRIPTION
CI fails because of the code coverage that goes down. Nothing we can do about it, this PR removes code, and the code that we're removing was tested, thus reducing the overall amount of code tested in our codebase. 