### PR TITLE
perf(packfile): add LRU cache for base objects

### DIFF
--- a/backend/fsbackend/objects.go
+++ b/backend/fsbackend/objects.go
@@ -69,6 +69,7 @@ func (b *Backend) looseObjectPath(sha string) string {
 // The format of an object is an ascii encoded type, an ascii encoded
 // space, then an ascii encoded length of the object, then a null
 // character, then the body of the object
+// TODO(melvin)"" Move to ginternals (NewFromLoose or something)
 func (b *Backend) looseObject(oid ginternals.Oid) (o *object.Object, err error) {
 	strOid := oid.String()
 
@@ -130,7 +131,7 @@ func (b *Backend) looseObject(oid ginternals.Oid) (o *object.Object, err error) 
 		return nil, xerrors.Errorf("object marked as size %d, but has %d at path %s: %w", oSize, len(oContent), p, err)
 	}
 
-	return object.NewWithID(oid, oType, oContent), nil
+	return object.New(oType, oContent), nil
 }
 
 // loadPacks loads the packfiles in memory

--- a/backend/fsbackend/objects.go
+++ b/backend/fsbackend/objects.go
@@ -69,7 +69,7 @@ func (b *Backend) looseObjectPath(sha string) string {
 // The format of an object is an ascii encoded type, an ascii encoded
 // space, then an ascii encoded length of the object, then a null
 // character, then the body of the object
-// TODO(melvin)"" Move to ginternals (NewFromLoose or something)
+// TODO(melvin): Move to ginternals (NewFromLoose or something)
 func (b *Backend) looseObject(oid ginternals.Oid) (o *object.Object, err error) {
 	strOid := oid.String()
 

--- a/ginternals/object/blob.go
+++ b/ginternals/object/blob.go
@@ -14,11 +14,6 @@ func NewBlob(o *Object) *Blob {
 	}
 }
 
-// IsPersisted returns whether the object has been written to the odb
-func (b *Blob) IsPersisted() bool {
-	return b.rawObject.id != ginternals.NullOid
-}
-
 // ID returns the blob's ID
 func (b *Blob) ID() ginternals.Oid {
 	return b.rawObject.id

--- a/ginternals/object/blob_test.go
+++ b/ginternals/object/blob_test.go
@@ -3,7 +3,6 @@ package object_test
 import (
 	"testing"
 
-	"github.com/Nivl/git-go/ginternals"
 	"github.com/Nivl/git-go/ginternals/object"
 	"github.com/stretchr/testify/assert"
 )
@@ -21,8 +20,6 @@ func TestBlob(t *testing.T) {
 		assert.Equal(t, 22, blob.Size())
 		assert.Equal(t, []byte(data), blob.Bytes())
 		assert.Equal(t, []byte(data), blob.BytesCopy())
-		assert.False(t, blob.IsPersisted())
-		assert.Equal(t, ginternals.NullOid, blob.ID())
 
 		assert.Equal(t, o, blob.ToObject())
 	})

--- a/ginternals/object/commit.go
+++ b/ginternals/object/commit.go
@@ -178,7 +178,7 @@ func NewCommit(treeID ginternals.Oid, author Signature, opts *CommitOptions) *Co
 // - The gpgsig is optional
 func NewCommitFromObject(o *Object) (*Commit, error) {
 	if o.typ != TypeCommit {
-		return nil, xerrors.Errorf("type %s is not a commit", o.typ)
+		return nil, xerrors.Errorf("type %s is not a commit: %w", o.typ, ErrObjectInvalid)
 	}
 	ci := &Commit{
 		rawObject: o,

--- a/ginternals/object/commit.go
+++ b/ginternals/object/commit.go
@@ -124,7 +124,6 @@ type Commit struct {
 	message string
 
 	parentIDs []ginternals.Oid
-	id        ginternals.Oid
 	treeID    ginternals.Oid
 }
 
@@ -143,12 +142,14 @@ func NewCommit(treeID ginternals.Oid, author Signature, opts *CommitOptions) *Co
 		c.committer = author
 	}
 
+	c.rawObject = c.ToObject()
+
 	return c
 }
 
 // ID returns the SHA of the commit object
 func (c *Commit) ID() ginternals.Oid {
-	return c.id
+	return c.rawObject.ID()
 }
 
 // Author returns the Signature of the person that made the changes

--- a/ginternals/object/commit_test.go
+++ b/ginternals/object/commit_test.go
@@ -34,6 +34,7 @@ func TestNewSignatureFromBytes(t *testing.T) {
 		desc                 string
 		signature            string
 		expectsError         bool
+		expectsErrorMatch    string
 		expectedName         string
 		expectedEmail        string
 		expectedTimestamp    int64
@@ -67,9 +68,10 @@ func TestNewSignatureFromBytes(t *testing.T) {
 			expectedTzOffsetMult: 0,
 		},
 		{
-			desc:         "invalid offset",
-			signature:    "Melvin Laplanche <melvin.wont.reply@gmail.com> 1566005917 nope",
-			expectsError: true,
+			desc:              "invalid offset",
+			signature:         "Melvin Laplanche <melvin.wont.reply@gmail.com> 1566005917 nope",
+			expectsError:      true,
+			expectsErrorMatch: "invalid timezone format",
 		},
 		{
 			desc:                 "valid with a single word name",
@@ -99,24 +101,58 @@ func TestNewSignatureFromBytes(t *testing.T) {
 			expectedTzOffsetMult: -7,
 		},
 		{
-			desc:         "invalid timestamp",
-			signature:    "Melvin Laplanche <melvin.wont.reply@gmail.com> nope -0700",
-			expectsError: true,
+			desc:              "invalid timestamp",
+			signature:         "Melvin Laplanche <melvin.wont.reply@gmail.com> nope -0700",
+			expectsError:      true,
+			expectsErrorMatch: "invalid timestamp",
 		},
 		{
-			desc:         "invalid email",
-			signature:    "Melvin Laplanche melvin.wont.reply@gmail.com 1566005917 -0700",
-			expectsError: true,
+			desc:              "invalid email",
+			signature:         "Melvin Laplanche melvin.wont.reply@gmail.com 1566005917 -0700",
+			expectsError:      true,
+			expectsErrorMatch: "signature stopped after the name",
 		},
 		{
-			desc:         "empty sig",
-			signature:    "",
-			expectsError: true,
+			desc:              "empty sig",
+			signature:         "",
+			expectsError:      true,
+			expectsErrorMatch: "couldn't retrieve the name",
 		},
 		{
-			desc:         "incomplete sig",
-			signature:    "Melvin Laplanche <melvin.wont.reply@gmail.com>",
-			expectsError: true,
+			desc:              "Name only",
+			signature:         "Melvin Laplanche",
+			expectsErrorMatch: "signature stopped after the name",
+			expectsError:      true,
+		},
+		{
+			desc:              "incomplete sig",
+			signature:         "Melvin Laplanche <melvin.wont.reply@gmail.com>",
+			expectsError:      true,
+			expectsErrorMatch: "signature stopped after the email",
+		},
+		{
+			desc:              "Email not closing",
+			signature:         "Melvin Laplanche <melvin.wont.reply@gmail.com",
+			expectsError:      true,
+			expectsErrorMatch: "couldn't retrieve the email",
+		},
+		{
+			desc:              "email opened but no content",
+			signature:         "Melvin Laplanche <",
+			expectsErrorMatch: "couldn't retrieve the email",
+			expectsError:      true,
+		},
+		{
+			desc:              "Missing timestamp",
+			signature:         "Melvin Laplanche <melvin.wont.reply@gmail.com> -0700",
+			expectsError:      true,
+			expectsErrorMatch: "invalid timestamp",
+		},
+		{
+			desc:              "Missing timestamp",
+			signature:         "Melvin Laplanche <melvin.wont.reply@gmail.com>  ",
+			expectsError:      true,
+			expectsErrorMatch: "signature stopped after the timestamp",
 		},
 	}
 	for _, tc := range testCases {
@@ -127,6 +163,10 @@ func TestNewSignatureFromBytes(t *testing.T) {
 			sig, err := object.NewSignatureFromBytes([]byte(tc.signature))
 			if tc.expectsError {
 				require.Error(t, err, "NewSignatureFromBytes should have failed")
+
+				if tc.expectsErrorMatch != "" {
+					assert.Contains(t, err.Error(), tc.expectsErrorMatch)
+				}
 				return
 			}
 
@@ -325,5 +365,96 @@ func TestCommitToObject(t *testing.T) {
 		assert.Equal(t, ci.ParentIDs(), ci2.ParentIDs())
 		assert.Equal(t, ci.GPGSig(), ci2.GPGSig())
 		assert.Equal(t, ci.TreeID(), ci2.TreeID())
+	})
+}
+
+func TestNewCommitFromObject(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should work on a valid commit", func(t *testing.T) {
+		t.Parallel()
+
+		// Find a commit
+		repoPath, cleanup := testhelper.UnTar(t, testhelper.RepoSmall)
+		t.Cleanup(cleanup)
+
+		r, err := git.OpenRepository(repoPath)
+		require.NoError(t, err, "failed loading a repo")
+		require.NotNil(t, r, "repository should not be nil")
+		t.Cleanup(func() {
+			require.NoError(t, r.Close())
+		})
+
+		commitID, err := ginternals.NewOidFromStr("bbb720a96e4c29b9950a4c577c98470a4d5dd089")
+		require.NoError(t, err)
+
+		o, err := r.GetObject(commitID)
+		require.NoError(t, err, "failed loading a repo")
+
+		_, err = object.NewCommitFromObject(o)
+		require.NoError(t, err)
+	})
+
+	t.Run("should fail if the object is not a commit", func(t *testing.T) {
+		t.Parallel()
+
+		o := object.New(object.TypeBlob, []byte{})
+		_, err := object.NewCommitFromObject(o)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a commit")
+	})
+
+	t.Run("parsing failures", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			desc               string
+			data               string
+			expectedErrorMatch string
+			expectedError      error
+		}{
+			{
+				desc:          "should fail if the commit has invalid content",
+				data:          "invalid data",
+				expectedError: object.ErrCommitInvalid,
+			},
+			{
+				desc:               "should fail if the tree id is invalid",
+				data:               "tree adad\n",
+				expectedErrorMatch: "could not parse tree id",
+			},
+			{
+				desc:               "should fail if the parent id is invalid",
+				data:               "parent adad\n",
+				expectedErrorMatch: "could not parse parent id",
+			},
+			{
+				desc:               "should fail if the author is invalid",
+				data:               "author adad\n",
+				expectedErrorMatch: "could not parse author signature",
+			},
+			{
+				desc:               "should fail if the committer is invalid",
+				data:               "committer adad\n",
+				expectedErrorMatch: "could not parse committer signature",
+			},
+		}
+		for i, tc := range testCases {
+			tc := tc
+			i := i
+			t.Run(fmt.Sprintf("%d/%s", i, tc.desc), func(t *testing.T) {
+				t.Parallel()
+
+				o := object.New(object.TypeCommit, []byte(tc.data))
+				_, err := object.NewCommitFromObject(o)
+				require.Error(t, err)
+				if tc.expectedError != nil {
+					assert.Error(t, err)
+				}
+				if tc.expectedErrorMatch != "" {
+					assert.Contains(t, err.Error(), tc.expectedErrorMatch)
+				}
+			})
+		}
 	})
 }

--- a/ginternals/object/commit_test.go
+++ b/ginternals/object/commit_test.go
@@ -401,6 +401,7 @@ func TestNewCommitFromObject(t *testing.T) {
 		o := object.New(object.TypeBlob, []byte{})
 		_, err := object.NewCommitFromObject(o)
 		require.Error(t, err)
+		assert.ErrorIs(t, err, object.ErrObjectInvalid)
 		assert.Contains(t, err.Error(), "is not a commit")
 	})
 
@@ -449,7 +450,7 @@ func TestNewCommitFromObject(t *testing.T) {
 				_, err := object.NewCommitFromObject(o)
 				require.Error(t, err)
 				if tc.expectedError != nil {
-					assert.Error(t, err)
+					assert.ErrorIs(t, err, tc.expectedError)
 				}
 				if tc.expectedErrorMatch != "" {
 					assert.Contains(t, err.Error(), tc.expectedErrorMatch)

--- a/ginternals/object/commit_test.go
+++ b/ginternals/object/commit_test.go
@@ -420,6 +420,11 @@ func TestNewCommitFromObject(t *testing.T) {
 				expectedError: object.ErrCommitInvalid,
 			},
 			{
+				desc:          "should fail if the commit has incomplete content",
+				data:          "invalid data\n",
+				expectedError: object.ErrCommitInvalid,
+			},
+			{
 				desc:               "should fail if the tree id is invalid",
 				data:               "tree adad\n",
 				expectedErrorMatch: "could not parse tree id",

--- a/ginternals/object/object.go
+++ b/ginternals/object/object.go
@@ -200,7 +200,7 @@ func (o *Object) AsBlob() *Blob {
 
 // AsTree parses the object as Tree
 func (o *Object) AsTree() (*Tree, error) {
-	return newTreeFromObject(o)
+	return NewTreeFromObject(o)
 }
 
 // AsCommit parses the object as Commit

--- a/ginternals/object/object.go
+++ b/ginternals/object/object.go
@@ -205,87 +205,8 @@ func (o *Object) AsTree() (*Tree, error) {
 }
 
 // AsCommit parses the object as Commit
-//
-// A commit has following format:
-//
-// tree {sha}
-// parent {sha}
-// author {author_name} <{author_email}> {author_date_seconds} {author_date_timezone}
-// committer {committer_name} <{committer_email}> {committer_date_seconds} {committer_date_timezone}
-// gpgsig -----BEGIN PGP SIGNATURE-----
-// {gpg key over multiple lines}
-//  -----END PGP SIGNATURE-----
-// {a blank line}
-// {commit message}
-//
-// Note:
-// - A commit can have 0, 1, or many parents lines
-//   The very first commit of a repo has no parents
-//   A regular commit as 1 parent
-//   A merge commit has 2 or more parents
-// - The gpgsig is optional
 func (o *Object) AsCommit() (*Commit, error) {
-	if o.typ != TypeCommit {
-		return nil, xerrors.Errorf("type %s is not a commit", o.typ)
-	}
-	ci := &Commit{
-		rawObject: o,
-	}
-	offset := 0
-	objData := o.Bytes()
-	for {
-		line := readutil.ReadTo(objData[offset:], '\n')
-		offset += len(line) + 1 // +1 to count the \n
-
-		// If we didn't find anything then something is wrong
-		if len(line) == 0 && offset == 1 {
-			return nil, xerrors.Errorf("could not find commit first line: %w", ErrCommitInvalid)
-		}
-
-		// if we got an empty line, it means everything from now to the end
-		// will be the commit message
-		if len(line) == 0 {
-			ci.message = string(objData[offset:])
-			break
-		}
-
-		// Otherwise we're getting a key/value pair, separated by a space
-		kv := bytes.SplitN(line, []byte{' '}, 2)
-		switch string(kv[0]) {
-		case "tree":
-			oid, err := ginternals.NewOidFromChars(kv[1])
-			if err != nil {
-				return nil, xerrors.Errorf("could not parse tree id %#v: %w", kv[1], err)
-			}
-			ci.treeID = oid
-		case "parent":
-			oid, err := ginternals.NewOidFromChars(kv[1])
-			if err != nil {
-				return nil, xerrors.Errorf("could not parse parent id %#v: %w", kv[1], err)
-			}
-			ci.parentIDs = append(ci.parentIDs, oid)
-		case "author":
-			sig, err := NewSignatureFromBytes(kv[1])
-			if err != nil {
-				return nil, xerrors.Errorf("could not parse signature [%s]: %w", string(kv[1]), err)
-			}
-			ci.author = sig
-		case "committer":
-			sig, err := NewSignatureFromBytes(kv[1])
-			if err != nil {
-				return nil, xerrors.Errorf("could not parse signature [%s]: %w", string(kv[1]), err)
-			}
-			ci.committer = sig
-		case "gpgsig":
-			begin := string(kv[1]) + "\n"
-			end := "-----END PGP SIGNATURE-----"
-			i := bytes.Index(objData[offset:], []byte(end))
-			ci.gpgSig = begin + string(objData[offset:offset+i]) + end
-			offset += len(end) + i + 1 // +1 to count the \n
-		}
-	}
-
-	return ci, nil
+	return NewCommitFromObject(o)
 }
 
 // AsTag parses the object as Tag

--- a/ginternals/object/object.go
+++ b/ginternals/object/object.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Nivl/git-go/ginternals"
 	"github.com/Nivl/git-go/internal/errutil"
-	"github.com/Nivl/git-go/internal/readutil"
 	"golang.org/x/xerrors"
 )
 
@@ -210,78 +209,6 @@ func (o *Object) AsCommit() (*Commit, error) {
 }
 
 // AsTag parses the object as Tag
-//
-// A tag has following format:
-//
-// object {sha}
-// type {target_object_type}
-// tag {tag_name}
-// tagger {author_name} <{author_email}> {author_date_seconds} {author_date_timezone}
-// gpgsig -----BEGIN PGP SIGNATURE-----
-// {gpg key over multiple lines}
-//  -----END PGP SIGNATURE-----
-// {a blank line}
-// {tag message}
-//
-// Note:
-// - The gpgsig is optional
 func (o *Object) AsTag() (*Tag, error) {
-	if o.typ != TypeTag {
-		return nil, xerrors.Errorf("type %s is not a tag", o.typ)
-	}
-	tag := &Tag{
-		id:        o.ID(),
-		rawObject: o,
-	}
-	offset := 0
-	objData := o.Bytes()
-	for {
-		line := readutil.ReadTo(objData[offset:], '\n')
-		offset += len(line) + 1 // +1 to count the \n
-
-		// If we didn't find anything then something is wrong
-		if len(line) == 0 && offset == 1 {
-			return nil, xerrors.Errorf("could not find tag first line: %w", ErrTagInvalid)
-		}
-
-		// if we got an empty line, it means everything from now to the end
-		// will be the tag message
-		if len(line) == 0 {
-			tag.message = string(objData[offset:])
-			break
-		}
-
-		// Otherwise we're getting a key/value pair, separated by a space
-		kv := bytes.SplitN(line, []byte{' '}, 2)
-		switch string(kv[0]) {
-		case "object":
-			oid, err := ginternals.NewOidFromChars(kv[1])
-			if err != nil {
-				return nil, xerrors.Errorf("could not parse target id %#v: %w", kv[1], err)
-			}
-			tag.target = oid
-		case "type":
-			typ, err := NewTypeFromString(string(kv[1]))
-			if err != nil {
-				return nil, xerrors.Errorf("object type %s: %w", string(kv[1]), err)
-			}
-			tag.typ = typ
-		case "tagger":
-			sig, err := NewSignatureFromBytes(kv[1])
-			if err != nil {
-				return nil, xerrors.Errorf("could not parse signature [%s]: %w", string(kv[1]), err)
-			}
-			tag.tagger = sig
-		case "tag":
-			tag.tag = string(kv[1])
-		case "gpgsig":
-			begin := string(kv[1]) + "\n"
-			end := "-----END PGP SIGNATURE-----"
-			i := bytes.Index(objData[offset:], []byte(end))
-			tag.gpgSig = begin + string(objData[offset:offset+i]) + end
-			offset += len(end) + i + 1 // +1 to count the \n
-		}
-	}
-
-	return tag, nil
+	return NewTagFromObject(o)
 }

--- a/ginternals/object/object.go
+++ b/ginternals/object/object.go
@@ -200,13 +200,6 @@ func (o *Object) AsBlob() *Blob {
 }
 
 // AsTree parses the object as Tree
-//
-// A tree has following format:
-//
-// {octal_mode} {path_name}\0{encoded_sha}
-//
-// Note:
-// - a Tree may have multiple entries
 func (o *Object) AsTree() (*Tree, error) {
 	return newTreeFromObject(o)
 }

--- a/ginternals/object/object_test.go
+++ b/ginternals/object/object_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Nivl/git-go/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestAsCommit(t *testing.T) {
@@ -22,7 +21,6 @@ func TestAsCommit(t *testing.T) {
 		t.Parallel()
 
 		treeID, _ := ginternals.NewOidFromStr("f0b577644139c6e04216d82f1dd4a5a63addeeca")
-		oid, _ := ginternals.NewOidFromStr("0343d67ca3d80a531d0d163f0078a81c95c9085a")
 		parentID, _ := ginternals.NewOidFromStr("9785af758bcc96cd7237ba65eb2c9dd1ecaa3321")
 
 		var b bytes.Buffer
@@ -60,7 +58,7 @@ commit body
 commit footer`)
 		rawData := b.Bytes()
 
-		o := object.NewWithID(oid, object.TypeCommit, rawData)
+		o := object.New(object.TypeCommit, rawData)
 		expectedSigName := "Melvin Laplanche"
 		expectedSigEmail := "melvin.wont.reply@gmail.com"
 		expectedSigTimestamp := int64(1566115917)
@@ -123,13 +121,12 @@ func TestAsTree(t *testing.T) {
 		t.Parallel()
 
 		treeSHA := "e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"
-		treeID, _ := ginternals.NewOidFromStr(treeSHA)
 
 		testFile := fmt.Sprintf("tree_%s", treeSHA)
 		content, err := ioutil.ReadFile(filepath.Join(testhelper.TestdataPath(t), testFile))
 		require.NoError(t, err)
 
-		o := object.NewWithID(treeID, object.TypeTree, content)
+		o := object.New(object.TypeTree, content)
 		tree, err := o.AsTree()
 		require.NoError(t, err)
 
@@ -144,10 +141,7 @@ func TestAsBlob(t *testing.T) {
 	content, err := ioutil.ReadFile(filepath.Join(testhelper.TestdataPath(t), "blob_642480605b8b0fd464ab5762e044269cf29a60a3"))
 	require.NoError(t, err)
 
-	sha, err := ginternals.NewOidFromStr("642480605b8b0fd464ab5762e044269cf29a60a3")
-	require.NoError(t, err)
-
-	o := object.NewWithID(sha, object.TypeBlob, content)
+	o := object.New(object.TypeBlob, content)
 	blob := o.AsBlob()
 
 	assert.Equal(t, o.ID(), blob.ID())
@@ -335,34 +329,17 @@ func TestCompress(t *testing.T) {
 		t.Parallel()
 
 		treeSHA := "e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"
-		treeID, _ := ginternals.NewOidFromStr(treeSHA)
 
 		testFile := fmt.Sprintf("tree_%s", treeSHA)
 		content, err := ioutil.ReadFile(filepath.Join(testhelper.TestdataPath(t), testFile))
 		require.NoError(t, err)
 
-		o := object.NewWithID(treeID, object.TypeTree, content)
+		o := object.New(object.TypeTree, content)
 		_, err = o.Compress()
 		require.NoError(t, err)
 		assert.Equal(t, treeSHA, o.ID().String())
 
 		// TODO(melvin): Test the compressed object
-	})
-
-	t.Run("should fail if ID missmatch", func(t *testing.T) {
-		t.Parallel()
-
-		fakeTreeID, err := ginternals.NewOidFromStr("d5b9e846e1b468bc9597ff95d71dfacda8bd54e3")
-		require.NoError(t, err)
-
-		testFile := "tree_e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"
-		content, err := ioutil.ReadFile(filepath.Join(testhelper.TestdataPath(t), testFile))
-		require.NoError(t, err)
-
-		o := object.NewWithID(fakeTreeID, object.TypeTree, content)
-		_, err = o.Compress()
-		require.Error(t, err)
-		require.True(t, xerrors.Is(err, object.ErrObjectInvalid))
 	})
 }
 
@@ -372,7 +349,6 @@ func TestAsTag(t *testing.T) {
 	t.Run("regular tag with all the fields", func(t *testing.T) {
 		t.Parallel()
 
-		oid, _ := ginternals.NewOidFromStr("0343d67ca3d80a531d0d163f0078a81c95c9085a")
 		objID, _ := ginternals.NewOidFromStr("9785af758bcc96cd7237ba65eb2c9dd1ecaa3321")
 
 		var b bytes.Buffer
@@ -403,7 +379,7 @@ gpgsig -----BEGIN PGP SIGNATURE-----
 tag message`)
 		rawData := b.Bytes()
 
-		o := object.NewWithID(oid, object.TypeTag, rawData)
+		o := object.New(object.TypeTag, rawData)
 		expectedSigName := "Melvin Laplanche"
 		expectedSigEmail := "melvin.wont.reply@gmail.com"
 		expectedSigTimestamp := int64(1566115917)

--- a/ginternals/object/tag.go
+++ b/ginternals/object/tag.go
@@ -33,10 +33,6 @@ type Tag struct {
 
 // NewTag creates a new Tag object
 func NewTag(p *TagParams) (*Tag, error) {
-	if p.Target.ID().IsZero() {
-		return nil, ErrObjectInvalid
-	}
-
 	return &Tag{
 		target:  p.Target.ID(),
 		typ:     p.Target.Type(),

--- a/ginternals/object/tag_test.go
+++ b/ginternals/object/tag_test.go
@@ -32,14 +32,13 @@ func TestNewTag(t *testing.T) {
 		commit, err := r.GetCommit(commitOid)
 		require.NoError(t, err)
 
-		tag, err := object.NewTag(&object.TagParams{
+		tag := object.NewTag(&object.TagParams{
 			Target:    commit.ToObject(),
 			Message:   "message",
 			OptGPGSig: "gpgsig",
 			Name:      "v10.5.0",
 			Tagger:    object.NewSignature("tagger", "tagger@domain.tld"),
 		})
-		require.NoError(t, err)
 		assert.True(t, tag.ID().IsZero(), "")
 		assert.Equal(t, commitOid, tag.Target())
 		assert.Equal(t, object.TypeCommit, tag.Type())
@@ -93,14 +92,13 @@ func TestTagToObject(t *testing.T) {
 		commit, err := r.GetCommit(commitOid)
 		require.NoError(t, err)
 
-		tag, err := object.NewTag(&object.TagParams{
+		tag := object.NewTag(&object.TagParams{
 			Target:    commit.ToObject(),
 			Message:   "message",
 			Name:      "v10.5.0",
 			OptGPGSig: "-----BEGIN PGP SIGNATURE-----\n\ndata\n-----END PGP SIGNATURE-----",
 			Tagger:    object.NewSignature("tagger", "tagger@domain.tld"),
 		})
-		require.NoError(t, err)
 
 		o := tag.ToObject()
 		tag2, err := o.AsTag()

--- a/ginternals/object/tag_test.go
+++ b/ginternals/object/tag_test.go
@@ -1,7 +1,6 @@
 package object_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/Nivl/git-go/ginternals/object"
@@ -48,21 +47,6 @@ func TestNewTag(t *testing.T) {
 		assert.Equal(t, "v10.5.0", tag.Name())
 		assert.Equal(t, "gpgsig", tag.GPGSig())
 		assert.Equal(t, "tagger", tag.Tagger().Name)
-	})
-
-	t.Run("non-persisted object should fail", func(t *testing.T) {
-		t.Parallel()
-
-		blob := object.New(object.TypeBlob, []byte(""))
-		_, err := object.NewTag(&object.TagParams{
-			Target:    blob,
-			Message:   "message",
-			OptGPGSig: "gpgsig",
-			Name:      "v10.5.0",
-			Tagger:    object.NewSignature("tagger", "tagger@domain.tld"),
-		})
-		require.Error(t, err)
-		require.True(t, errors.Is(err, object.ErrObjectInvalid), "invalid error")
 	})
 }
 

--- a/ginternals/object/tree.go
+++ b/ginternals/object/tree.go
@@ -116,8 +116,8 @@ func (t *Tree) ToObject() *Object {
 		buf.Write(e.ID.Bytes())
 	}
 
-	if t.id != ginternals.NullOid {
-		return NewWithID(t.id, TypeTree, buf.Bytes())
+	if !t.id.IsZero() {
+		return New(TypeTree, buf.Bytes())
 	}
 	return New(TypeTree, buf.Bytes())
 }

--- a/ginternals/object/tree_test.go
+++ b/ginternals/object/tree_test.go
@@ -40,15 +40,11 @@ func TestTree(t *testing.T) {
 	t.Run("Entries should be immutable", func(t *testing.T) {
 		t.Parallel()
 
-		treeSHA := "e5b9e846e1b468bc9597ff95d71dfacda8bd54e3"
-		treeID, err := ginternals.NewOidFromStr(treeSHA)
-		require.NoError(t, err)
-
 		blobSHA := "0343d67ca3d80a531d0d163f0078a81c95c9085a"
 		blobID, err := ginternals.NewOidFromStr(blobSHA)
 		require.NoError(t, err)
 
-		tree := object.NewTreeWithID(treeID, []object.TreeEntry{
+		tree := object.NewTree([]object.TreeEntry{
 			{
 				Mode: object.ModeFile,
 				ID:   blobID,

--- a/ginternals/object/tree_test.go
+++ b/ginternals/object/tree_test.go
@@ -27,12 +27,13 @@ func TestTree(t *testing.T) {
 		content, err := ioutil.ReadFile(filepath.Join(testhelper.TestdataPath(t), testFile))
 		require.NoError(t, err)
 
-		o := object.NewWithID(treeID, object.TypeTree, content)
+		o := object.New(object.TypeTree, content)
 		tree, err := o.AsTree()
 		require.NoError(t, err)
 
 		newO := tree.ToObject()
 		require.Equal(t, o.ID(), newO.ID())
+		require.Equal(t, treeID, newO.ID())
 		require.Equal(t, o.Bytes(), newO.Bytes())
 	})
 

--- a/repo.go
+++ b/repo.go
@@ -271,9 +271,17 @@ func (r *Repository) NewDetachedCommit(tree *object.Tree, author object.Signatur
 
 // NewTag creates, stores, and returns a new annoted tag
 func (r *Repository) NewTag(p *object.TagParams) (*object.Tag, error) {
+	found, err := r.dotGit.HasObject(p.Target.ID())
+	if err != nil {
+		return nil, xerrors.Errorf("could not check if target exists: %w", err)
+	}
+	if !found {
+		return nil, xerrors.Errorf("target doesn't exists: %w", object.ErrObjectInvalid)
+	}
+
 	// We first make sure the tag doesn't already exist
 	refname := gitpath.LocalTag(p.Name)
-	_, err := r.dotGit.Reference(refname)
+	_, err = r.dotGit.Reference(refname)
 	if err == nil {
 		return nil, ErrTagExists
 	}
@@ -302,12 +310,17 @@ func (r *Repository) NewTag(p *object.TagParams) (*object.Tag, error) {
 
 // NewLightweightTag creates, stores, and returns a lightweight tag
 func (r *Repository) NewLightweightTag(tag string, targetID ginternals.Oid) (*ginternals.Reference, error) {
-	if targetID.IsZero() {
-		return nil, object.ErrObjectInvalid
+	// let's make sure the object exists
+	found, err := r.dotGit.HasObject(targetID)
+	if err != nil {
+		return nil, xerrors.Errorf("could not retrieve targeted object: %w", err)
+	}
+	if !found {
+		return nil, xerrors.Errorf("target : %w", object.ErrObjectInvalid)
 	}
 
 	refname := gitpath.LocalTag(tag)
-	_, err := r.dotGit.Reference(refname)
+	_, err = r.dotGit.Reference(refname)
 	if err == nil {
 		return nil, ErrTagExists
 	}

--- a/repo.go
+++ b/repo.go
@@ -290,11 +290,7 @@ func (r *Repository) NewTag(p *object.TagParams) (*object.Tag, error) {
 	}
 
 	// We create the tag and persist it to the object database
-	c, err := object.NewTag(p)
-	if err != nil {
-		return nil, xerrors.Errorf("could not create the object: %w", err)
-	}
-	o := c.ToObject()
+	o := object.NewTag(p).ToObject()
 	if _, err := r.dotGit.WriteObject(o); err != nil {
 		return nil, xerrors.Errorf("could not write the object to the odb: %w", err)
 	}

--- a/repo_test.go
+++ b/repo_test.go
@@ -538,7 +538,7 @@ func TestRepositoryNewTag(t *testing.T) {
 			Message: "incvalid",
 		})
 		require.Error(t, err)
-		require.True(t, errors.Is(err, object.ErrObjectInvalid))
+		require.True(t, errors.Is(err, object.ErrObjectInvalid), "got: %s", err.Error())
 	})
 }
 
@@ -605,6 +605,6 @@ func TestRepositoryNewLightweightTag(t *testing.T) {
 		// Create the tag
 		_, err = r.NewLightweightTag("v0.0.1-test", blob.ID())
 		require.Error(t, err)
-		require.True(t, errors.Is(err, object.ErrObjectInvalid))
+		require.True(t, errors.Is(err, object.ErrObjectInvalid), "got: %s", err.Error())
 	})
 }

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -79,7 +79,7 @@ func (tb *TreeBuilder) Remove(path string) {
 func (tb *TreeBuilder) Write() (*object.Tree, error) {
 	// We need to order all our entries alphabetically
 	// We're going to extract the paths of the map
-	// they just loop over the keys instead of the entries
+	// and just loop over the keys instead of the entries
 	paths := make([]string, 0, len(tb.entries))
 	for p := range tb.entries {
 		paths = append(paths, p)
@@ -96,5 +96,5 @@ func (tb *TreeBuilder) Write() (*object.Tree, error) {
 	if _, err := tb.Backend.WriteObject(o); err != nil {
 		return nil, xerrors.Errorf("could not write the object to the odb: %w", err)
 	}
-	return object.NewTreeWithID(o.ID(), t.Entries()), nil
+	return o.AsTree()
 }


### PR DESCRIPTION
The PR does two things:
- Add LRU cache for base objects in the packfile
- (as side effect) Refactor the object creation methods to never need an ID.
	- Strengthen validation when creating an object (so we don't create a tag with an invalid target for example)
	- Add a bunch of missing tests
	- Cleanup some `oid != ginternals.NullOid` (=> `!baseOid.IsZero()`)