### PR TITLE
ci: add Voorhees

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,4 @@
-name: CodeQL Security
+name: Security
 
 on:
   push:
@@ -37,7 +37,7 @@ jobs:
         uses: Nivl/voorhees-github-action@v1
 
   analyze:
-    name: Analyze
+    name: CodeQL Analyze
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,10 +1,4 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-name: "CodeQL"
+name: CodeQL Security
 
 on:
   push:
@@ -16,6 +10,32 @@ on:
     - cron: "17 8 * * 2"
 
 jobs:
+  go-vulnerabilities-scan:
+    name: "Golang Vulnerabilities Scan"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+
+      - name: Generate go.list
+        run: go list -json -m all > go.list
+
+      - name: Run Nancy
+        uses: sonatype-nexus-community/nancy-github-action@main
+
+  unmaintained-deps-check:
+    name: "Unmaintained deps check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+
+      - name: Generate go.list
+        run: go list -json -m all > go.list
+
+      - name: Run Voorhees
+        uses: Nivl/voorhees-github-action@v1
+
   analyze:
     name: Analyze
     runs-on: ubuntu-latest

--- a/.voorhees.yml
+++ b/.voorhees.yml
@@ -1,0 +1,7 @@
+version: 1
+default:
+  limit: 6 months
+rules:
+  # No release since Jan 2020 but still has some activity on Master
+  # mainteners are actively commenting on issues and PRs
+  github.com/hashicorp/golang-lru: 18 months

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/Nivl/git-go/branch/main/graph/badge.svg?token=I0YC2EHRHB)](https://codecov.io/gh/Nivl/git-go)
+
 # git-go
 
 Basic git implementation in pure Go

--- a/backend/fsbackend/fsbackend.go
+++ b/backend/fsbackend/fsbackend.go
@@ -39,10 +39,14 @@ type Backend struct {
 
 // New returns a new Backend object
 func New(dotGitPath string) (*Backend, error) {
+	c, err := cache.NewLRU(1000)
+	if err != nil {
+		return nil, xerrors.Errorf("could not create LRU cache: %w", err)
+	}
 	b := &Backend{
 		fs:        afero.NewOsFs(),
 		root:      dotGitPath,
-		cache:     cache.NewLRU(1000),
+		cache:     c,
 		objectMu:  syncutil.NewNamedMutex(101),
 		packfiles: map[ginternals.Oid]*packfile.Pack{},
 		refs:      map[string][]byte{},

--- a/ginternals/packfile/packfile.go
+++ b/ginternals/packfile/packfile.go
@@ -113,9 +113,13 @@ func NewFromFile(fs afero.Fs, filePath string) (pack *Pack, err error) {
 		}
 	}()
 
+	c, err := cache.NewLRU(1000)
+	if err != nil {
+		return nil, xerrors.Errorf("could not create LRU cache: %w", err)
+	}
 	p := &Pack{
 		r:               f,
-		baseObjectCache: cache.NewLRU(1000),
+		baseObjectCache: c,
 	}
 
 	// Let's validate the header

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/gogf/gf v1.15.1
-	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/spf13/afero v1.5.1
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,6 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
-github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -107,6 +105,8 @@ github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/cache/lru.go
+++ b/internal/cache/lru.go
@@ -32,7 +32,7 @@ func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
 }
 
 // Add adds a value to the cache.
-func (c *LRU) Add(key interface{}, value interface{}) {
+func (c *LRU) Add(key, value interface{}) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/internal/cache/lru.go
+++ b/internal/cache/lru.go
@@ -3,11 +3,8 @@ package cache
 import (
 	"sync"
 
-	lru "github.com/golang/groupcache/lru"
+	lru "github.com/hashicorp/golang-lru"
 )
-
-// LRUKey may be any value that is comparable. See http://golang.org/ref/spec#Comparison_operators
-type LRUKey = lru.Key
 
 // LRU represents a LRU cache
 type LRU struct {
@@ -16,16 +13,18 @@ type LRU struct {
 }
 
 // NewLRU creates a new LRU Cache.
-// If maxEntries is zero, the cache has no limit and it's assumed
-// that eviction is done by the caller.
-func NewLRU(maxEntries int) *LRU {
-	return &LRU{
-		cache: lru.New(maxEntries),
+func NewLRU(maxEntries int) (*LRU, error) {
+	cache, err := lru.New(maxEntries)
+	if err != nil {
+		return nil, err
 	}
+	return &LRU{
+		cache: cache,
+	}, nil
 }
 
 // Get looks up a key's value from the cache.
-func (c *LRU) Get(key LRUKey) (value interface{}, ok bool) {
+func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -33,7 +32,7 @@ func (c *LRU) Get(key LRUKey) (value interface{}, ok bool) {
 }
 
 // Add adds a value to the cache.
-func (c *LRU) Add(key LRUKey, value interface{}) {
+func (c *LRU) Add(key interface{}, value interface{}) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -45,7 +44,7 @@ func (c *LRU) Clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.cache.Clear()
+	c.cache.Purge()
 }
 
 // Len returns the number of items in the cache.

--- a/internal/cache/lru_test.go
+++ b/internal/cache/lru_test.go
@@ -37,4 +37,11 @@ func TestLRU(t *testing.T) {
 		c.Clear()
 		assert.Equal(t, 0, c.Len(), "expected the cache t have been emptied")
 	})
+
+	t.Run("Should fail on invalid limit", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := cache.NewLRU(0)
+		require.Error(t, err)
+	})
 }

--- a/internal/cache/lru_test.go
+++ b/internal/cache/lru_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Nivl/git-go/internal/cache"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLRU(t *testing.T) {
@@ -13,7 +14,8 @@ func TestLRU(t *testing.T) {
 	t.Run("Add and get data", func(t *testing.T) {
 		t.Parallel()
 
-		c := cache.NewLRU(1)
+		c, err := cache.NewLRU(1)
+		require.NoError(t, err)
 
 		assert.Equal(t, 0, c.Len(), "expected an empty cache")
 


### PR DESCRIPTION
- Add Voorhees
- Replace `golang/group cache` by `hashicorp/golang-lru` because the `golang/groupcache` team isn't actively responding to issues and PRs, and hasn't pushed any update in a year.