### PR TITLE
ci(linter): update go linter to 1.39

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.5.1
         with:
-          version: v1.37
+          version: v1.39
 
   codecov:
     name: "Codecov.yml"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,10 @@ issues:
         - errcheck
         - gosec
         - goerr113
-        - maligned
+        - forcetypeassert
+
+    - path: _test\.go
+      text: "fieldalignment: struct"
 
     # No need to check for non-wrapped errors in cmd/ since most
     # command might return inline errors
@@ -55,16 +58,13 @@ linters:
     - golint
     - stylecheck
     - gosec
-    - interfacer
     - unconvert
     - asciicheck
     - goimports
-    - maligned
     - misspell
     - unparam
     - dogsled
     - prealloc
-    - scopelint
     - gocritic
     - gochecknoinits
     - whitespace
@@ -80,13 +80,12 @@ linters:
     - revive
     - durationcheck
     - forbidigo
+    - forcetypeassert
+    - nilerr
 
 linters-settings:
-  maligned:
-    suggest-new: true
-
   govet:
-    check-shadowing: true
+    enable-all: true
 
   gocritic:
     enabled-tags:

--- a/backend/fsbackend/fsbackend.go
+++ b/backend/fsbackend/fsbackend.go
@@ -22,12 +22,6 @@ var _ backend.Backend = (*Backend)(nil)
 
 // Backend is a Backend implementation that uses the filesystem to store data
 type Backend struct {
-	// we use afero.Fs instead of the regular os package
-	// because some part of the library requires an Fs object.
-	// It's easier and cleaner to use the same thing everywhere.
-	fs   afero.Fs
-	root string
-
 	objectMu     *syncutil.NamedMutex
 	cache        *cache.LRU
 	looseObjects *sync.Map
@@ -35,6 +29,12 @@ type Backend struct {
 	packfiles map[ginternals.Oid]*packfile.Pack
 
 	refs *sync.Map
+
+	// we use afero.Fs instead of the regular os package
+	// because some part of the library requires an Fs object.
+	// It's easier and cleaner to use the same thing everywhere.
+	fs   afero.Fs
+	root string
 }
 
 // New returns a new Backend object

--- a/backend/fsbackend/objects.go
+++ b/backend/fsbackend/objects.go
@@ -143,7 +143,7 @@ func (b *Backend) loadPacks() error {
 	p := filepath.Join(b.root, gitpath.ObjectsPackPath)
 	return afero.Walk(b.fs, p, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
-			// in case of error we just skip it and move on.
+			//nolint:nilerr // in case of error we just skip it and move on.
 			// this will happen if the repo is empty and the ./objects/pack
 			// folder doesn't exists
 			return nil
@@ -274,7 +274,7 @@ func (b *Backend) loadLooseObject() error {
 	p := filepath.Join(b.root, gitpath.ObjectsPath)
 	return afero.Walk(b.fs, p, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
-			// in case of error we just skip it and move on.
+			//nolint:nilerr // in case of error we just skip it and move on.
 			// this will happen if the repo is empty and the ./objects
 			// folder doesn't exists
 			return nil

--- a/backend/fsbackend/reference.go
+++ b/backend/fsbackend/reference.go
@@ -178,7 +178,11 @@ func (b *Backend) writeReference(ref *ginternals.Reference) error {
 func (b *Backend) WalkReferences(f backend.RefWalkFunc) error {
 	var topError error
 	b.refs.Range(func(key, value interface{}) bool {
-		name := key.(string)
+		name, ok := key.(string)
+		if !ok {
+			topError = xerrors.Errorf("invalid key type for %s. expected string got %T", name, key)
+			return false
+		}
 		ref, err := b.Reference(name)
 		if err != nil {
 			topError = xerrors.Errorf("could not resolve reference %s: %w", name, err)

--- a/cmd/git-go/cat_file.go
+++ b/cmd/git-go/cat_file.go
@@ -45,11 +45,11 @@ func newCatFileCmd(cfg *config) *cobra.Command {
 }
 
 type catFileParams struct {
+	objectName  string
+	typ         string
 	typeOnly    bool
 	sizeOnly    bool
 	prettyPrint bool
-	objectName  string
-	typ         string
 }
 
 func catFileCmd(out io.Writer, cfg *config, p catFileParams) (err error) {

--- a/ginternals/object/commit.go
+++ b/ginternals/object/commit.go
@@ -19,9 +19,9 @@ var ErrSignatureInvalid = errors.New("commit signature is invalid")
 
 // Signature represents the author/committer and time of a commit
 type Signature struct {
+	Time  time.Time
 	Name  string
 	Email string
-	Time  time.Time
 }
 
 // String returns a stringified version of the Signature
@@ -114,12 +114,12 @@ func NewSignatureFromBytes(b []byte) (Signature, error) {
 
 // CommitOptions represents all the optional data available to create a commit
 type CommitOptions struct {
-	ParentsID []ginternals.Oid
-	Message   string
-	GPGSig    string
+	Message string
+	GPGSig  string
 	// Committer represent the person creating the commit.
 	// If not provided, the author will be used as committer
 	Committer Signature
+	ParentsID []ginternals.Oid
 }
 
 // Commit represents a commit object

--- a/ginternals/object/object.go
+++ b/ginternals/object/object.go
@@ -111,11 +111,10 @@ func NewTypeFromString(t string) (Type, error) {
 // (kind of an optimized git database) located in .git/objects/packs
 // https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
 type Object struct {
-	id      ginternals.Oid
-	typ     Type
-	content []byte
-
+	content      []byte
 	idProcessing sync.Once
+	typ          Type
+	id           ginternals.Oid
 }
 
 // New creates a new git object of the given type

--- a/ginternals/object/tag.go
+++ b/ginternals/object/tag.go
@@ -23,7 +23,6 @@ type Tag struct {
 	rawObject *Object
 
 	tagger  Signature
-	typ     Type
 	tag     string
 	message string
 
@@ -31,6 +30,8 @@ type Tag struct {
 
 	id     ginternals.Oid
 	target ginternals.Oid
+
+	typ Type
 }
 
 // NewTag creates a new Tag object

--- a/ginternals/object/tree.go
+++ b/ginternals/object/tree.go
@@ -62,9 +62,9 @@ type Tree struct {
 
 // TreeEntry represents an entry inside a git tree
 type TreeEntry struct {
-	Mode TreeObjectMode
-	ID   ginternals.Oid
 	Path string
+	ID   ginternals.Oid
+	Mode TreeObjectMode
 }
 
 // NewTree returns a new tree with the given entries

--- a/ginternals/packfile/packfile.go
+++ b/ginternals/packfile/packfile.go
@@ -83,12 +83,6 @@ type Pack struct {
 	r       afero.File
 	idxFile afero.File
 	idx     *PackIndex
-	header  [packfileHeaderSize]byte
-	id      ginternals.Oid
-
-	// Mutex used to protect the exported methods from being called
-	// concurrently
-	mu sync.Mutex
 
 	// baseObjectCache is a cache for all the base objects.
 	// We only cache the base objects for 2 reasons:
@@ -98,6 +92,13 @@ type Pack struct {
 	//   requesting. Here, we're mostly focused on improving the parsing
 	//   performances rather than just caching anything
 	baseObjectCache *cache.LRU
+
+	id     ginternals.Oid
+	header [packfileHeaderSize]byte
+
+	// Mutex used to protect the exported methods from being called
+	// concurrently
+	mu sync.Mutex
 }
 
 // NewFromFile returns a pack object from the given file

--- a/ginternals/packfile/packindex.go
+++ b/ginternals/packfile/packindex.go
@@ -82,7 +82,9 @@ func indexHeader() []byte {
 // Resources:
 // https://codewords.recurse.com/issues/three/unpacking-git-packfiles#idx-files
 // https://git-scm.com/docs/pack-format
-type PackIndex struct { //nolint:govet // aligning the memory makes the struct harder to read
+//
+//nolint:govet // aligning the memory makes the struct harder to read since we want to keep "parseError" and "parsed" together
+type PackIndex struct {
 	mu sync.Mutex
 
 	r          readutil.BufferedReader

--- a/ginternals/packfile/packindex.go
+++ b/ginternals/packfile/packindex.go
@@ -82,14 +82,14 @@ func indexHeader() []byte {
 // Resources:
 // https://codewords.recurse.com/issues/three/unpacking-git-packfiles#idx-files
 // https://git-scm.com/docs/pack-format
-type PackIndex struct {
+type PackIndex struct { //nolint:govet // aligning the memory makes the struct harder to read
+	mu sync.Mutex
+
 	r          readutil.BufferedReader
 	hashOffset map[ginternals.Oid]uint64
 
-	parsed     bool
 	parseError error
-
-	mu sync.Mutex
+	parsed     bool
 }
 
 // NewIndex returns an index object from the given reader

--- a/repo.go
+++ b/repo.go
@@ -29,10 +29,10 @@ var (
 // building a history over time.
 // https://blog.axosoft.com/learning-git-repository/
 type Repository struct {
-	dotGitPath string
-	dotGit     backend.Backend
-	repoRoot   string
 	wt         afero.Fs
+	dotGit     backend.Backend
+	dotGitPath string
+	repoRoot   string
 
 	shouldCleanBackend bool
 }
@@ -40,8 +40,6 @@ type Repository struct {
 // InitOptions contains all the optional data used to initialized a
 // repository
 type InitOptions struct {
-	// IsBare represents whether a bare repository will be created or not
-	IsBare bool
 	// GitBackend represents the underlying backend to use to init the
 	// repository and interact with the odb
 	// By default the filesystem will be used
@@ -51,6 +49,8 @@ type InitOptions struct {
 	// By default the filesystem will be used
 	// Setting this is useless if IsBare is set to true
 	WorkingTreeBackend afero.Fs
+	// IsBare represents whether a bare repository will be created or not
+	IsBare bool
 }
 
 // InitRepository initialize a new git repository by creating the .git
@@ -118,8 +118,6 @@ func InitRepositoryWithOptions(repoPath string, opts InitOptions) (r *Repository
 // OpenOptions contains all the optional data used to open a
 // repository
 type OpenOptions struct {
-	// IsBare represents whether a bare repository will be created or not
-	IsBare bool
 	// GitBackend represents the underlying backend to use to init the
 	// repository and interact with the odb
 	// By default the filesystem will be used
@@ -129,6 +127,8 @@ type OpenOptions struct {
 	// By default the filesystem will be used
 	// Setting this is useless if IsBare is set to true
 	WorkingTreeBackend afero.Fs
+	// IsBare represents whether a bare repository will be created or not
+	IsBare bool
 }
 
 // OpenRepository loads an existing git repository by reading its


### PR DESCRIPTION
* Update golangci-lint to latest version (v1.39)
* Remove/Replace deprecated linters
* Add new linters released with 1.38 and 1.39 

~/!\ Blocked until https://github.com/golangci/golangci-lint/pull/1872 is merged~