### PR TITLE
ci(voorhees): push gopkg.in/ini to 12 months

### DIFF
--- a/.voorhees.yml
+++ b/.voorhees.yml
@@ -20,3 +20,8 @@ rules:
   # No release since the last August 2020, nothing wrong. We probably
   # don't need the package though.
   golang.org/x/xerrors: 12 months
+
+  # No release since the last October 2020.
+  # Couple of PRs opened, a few issues as well, no activity from
+  # maintainer. Nothing too worriying yet.
+  gopkg.in/ini.v1: 12 months


### PR DESCRIPTION
`gopkg.in/ini.v1` triggered voorhees. Nothing worrying yet. See comment in changes for more information.