### PR TITLE
refactor(deps): replace xerrors by errors

### DIFF
--- a/.voorhees.yml
+++ b/.voorhees.yml
@@ -17,10 +17,6 @@ rules:
   # Link: https://github.com/golang/go/issues/26904#issuecomment-785234200
   github.com/spf13/pflag: 99 months
 
-  # No release since the last August 2020, nothing wrong. We probably
-  # don't need the package though.
-  golang.org/x/xerrors: 12 months
-
   # No release since the last October 2020.
   # Couple of PRs opened, a few issues as well, no activity from
   # maintainer. Nothing too worriying yet.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -3,6 +3,7 @@
 package backend
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/Nivl/git-go/ginternals"
@@ -11,7 +12,6 @@ import (
 	"github.com/Nivl/git-go/internal/cache"
 	"github.com/Nivl/git-go/internal/syncutil"
 	"github.com/spf13/afero"
-	"golang.org/x/xerrors"
 )
 
 // Backend is a Backend implementation that uses the filesystem to store data
@@ -38,7 +38,7 @@ func NewFS(params *config.GitParams) (*Backend, error) {
 func New(params *config.GitParams, fs afero.Fs) (*Backend, error) {
 	c, err := cache.NewLRU(1000)
 	if err != nil {
-		return nil, xerrors.Errorf("could not create LRU cache: %w", err)
+		return nil, fmt.Errorf("could not create LRU cache: %w", err)
 	}
 	b := &Backend{
 		params:       params,
@@ -81,16 +81,16 @@ func New(params *config.GitParams, fs afero.Fs) (*Backend, error) {
 	wg.Wait()
 
 	if loadRefsErr != nil {
-		return nil, xerrors.Errorf("could not load references: %w", loadRefsErr)
+		return nil, fmt.Errorf("could not load references: %w", loadRefsErr)
 	}
 	if loadPackErr != nil {
-		return nil, xerrors.Errorf("could not load packs: %w", loadPackErr)
+		return nil, fmt.Errorf("could not load packs: %w", loadPackErr)
 	}
 	if loadLooseObjectErr != nil {
-		return nil, xerrors.Errorf("could not load loose objects: %w", loadLooseObjectErr)
+		return nil, fmt.Errorf("could not load loose objects: %w", loadLooseObjectErr)
 	}
 	if loadConfigErr != nil {
-		return nil, xerrors.Errorf("could not load config: %w", loadConfigErr)
+		return nil, fmt.Errorf("could not load config: %w", loadConfigErr)
 	}
 
 	return b, nil
@@ -103,7 +103,7 @@ func (b *Backend) Close() (err error) {
 		if e := pack.Close(); e != nil {
 			// we don't return directly because we still want to try to
 			// close the other packfiles
-			err = xerrors.Errorf("could not close packfile %s: %w", oid.String(), err)
+			err = fmt.Errorf("could not close packfile %s: %w", oid.String(), err)
 		}
 	}
 	b.packfiles = map[ginternals.Oid]*packfile.Pack{}

--- a/backend/config.go
+++ b/backend/config.go
@@ -1,12 +1,12 @@
 package backend
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/Nivl/git-go/ginternals"
 	"github.com/Nivl/git-go/internal/gitpath"
-	"golang.org/x/xerrors"
 	"gopkg.in/ini.v1"
 )
 
@@ -28,7 +28,7 @@ func (b *Backend) Init() error {
 	}
 	for _, d := range dirs {
 		if err := b.fs.MkdirAll(d, 0o750); err != nil {
-			return xerrors.Errorf("could not create directory %s: %w", d, err)
+			return fmt.Errorf("could not create directory %s: %w", d, err)
 		}
 	}
 
@@ -46,18 +46,18 @@ func (b *Backend) Init() error {
 	for _, f := range files {
 		fullPath := filepath.Join(b.Path(), f.path)
 		if err := os.WriteFile(fullPath, f.content, 0o644); err != nil {
-			return xerrors.Errorf("could not create file %s: %w", f, err)
+			return fmt.Errorf("could not create file %s: %w", f, err)
 		}
 	}
 
 	err := b.setDefaultCfg()
 	if err != nil {
-		return xerrors.Errorf("could not set the default config: %w", err)
+		return fmt.Errorf("could not set the default config: %w", err)
 	}
 
 	ref := ginternals.NewSymbolicReference(ginternals.Head, gitpath.LocalBranch(ginternals.Master))
 	if err := b.WriteReferenceSafe(ref); err != nil {
-		return xerrors.Errorf("could not write HEAD: %w", err)
+		return fmt.Errorf("could not write HEAD: %w", err)
 	}
 
 	return nil
@@ -71,7 +71,7 @@ func (b *Backend) setDefaultCfg() error {
 	// Core
 	core, err := cfg.NewSection(CfgCore)
 	if err != nil {
-		return xerrors.Errorf("could not create core section: %w", err)
+		return fmt.Errorf("could not create core section: %w", err)
 	}
 	coreCfg := map[string]string{
 		CfgCoreFormatVersion:     "0",
@@ -83,7 +83,7 @@ func (b *Backend) setDefaultCfg() error {
 	}
 	for k, v := range coreCfg {
 		if _, err := core.NewKey(k, v); err != nil {
-			return xerrors.Errorf("could not set %s: %w", k, err)
+			return fmt.Errorf("could not set %s: %w", k, err)
 		}
 	}
 	return cfg.SaveTo(filepath.Join(b.Path(), gitpath.ConfigPath))

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -1,6 +1,7 @@
 package backend_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,7 +14,6 @@ import (
 	"github.com/Nivl/git-go/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestInit(t *testing.T) {
@@ -160,7 +160,7 @@ func TestInit(t *testing.T) {
 		err = b.Init()
 		require.Error(t, err)
 		var perror *os.PathError
-		require.True(t, xerrors.As(err, &perror), "error should be os.PathError")
+		require.True(t, errors.As(err, &perror), "error should be os.PathError")
 		assert.Equal(t, "permission denied", perror.Err.Error())
 	})
 
@@ -188,7 +188,7 @@ func TestInit(t *testing.T) {
 		err = b.Init()
 		require.Error(t, err)
 		var perror *os.PathError
-		require.True(t, xerrors.As(err, &perror), "error should be os.PathError")
+		require.True(t, errors.As(err, &perror), "error should be os.PathError")
 		assert.Contains(t, perror.Err.Error(), "denied")
 	})
 }

--- a/backend/objects.go
+++ b/backend/objects.go
@@ -110,7 +110,7 @@ func (b *Backend) looseObject(oid ginternals.Oid) (o *object.Object, err error) 
 
 	oType, err := object.NewTypeFromString(string(typ))
 	if err != nil {
-		return nil, fmt.Errorf("unsupported type %s for object %s at path %s", string(typ), strOid, p)
+		return nil, fmt.Errorf("unsupported type %s for object %s at path %s: %w", string(typ), strOid, p, object.ErrObjectInvalid)
 	}
 	pointerPos += len(typ)
 	pointerPos++ // one more for the space

--- a/backend/objects_test.go
+++ b/backend/objects_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Nivl/git-go/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestObject(t *testing.T) {
@@ -105,7 +104,7 @@ func TestObject(t *testing.T) {
 		obj, err := b.Object(oid)
 		require.Error(t, err)
 		require.Nil(t, obj)
-		require.True(t, xerrors.Is(err, ginternals.ErrObjectNotFound), "unexpected error received")
+		require.True(t, errors.Is(err, ginternals.ErrObjectNotFound), "unexpected error received")
 	})
 }
 

--- a/backend/reference.go
+++ b/backend/reference.go
@@ -179,6 +179,7 @@ func (b *Backend) WalkReferences(f RefWalkFunc) error {
 	b.refs.Range(func(key, value interface{}) bool {
 		name, ok := key.(string)
 		if !ok {
+			//nolint:goerr113 // no need to wrap the error, this would only be caused by a bug in the codebase
 			topError = fmt.Errorf("invalid key type for %s. expected string got %T", name, key)
 			return false
 		}

--- a/backend/reference_test.go
+++ b/backend/reference_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Nivl/git-go/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestReference(t *testing.T) {
@@ -37,7 +36,7 @@ func TestReference(t *testing.T) {
 		})
 		ref, err := b.Reference("refs/heads/doesnt_exists")
 		require.Error(t, err)
-		assert.True(t, xerrors.Is(ginternals.ErrRefNotFound, ginternals.ErrRefNotFound), "unexpected error returned")
+		assert.True(t, errors.Is(ginternals.ErrRefNotFound, ginternals.ErrRefNotFound), "unexpected error returned")
 		assert.Nil(t, ref)
 	})
 
@@ -162,7 +161,7 @@ func TestParsePackedRefs(t *testing.T) {
 
 		_, err = NewFS(opts)
 		require.Error(t, err)
-		assert.True(t, xerrors.Is(err, ginternals.ErrPackedRefInvalid), "unexpected error received")
+		assert.True(t, errors.Is(err, ginternals.ErrPackedRefInvalid), "unexpected error received")
 	})
 
 	t.Run("Should pass with comments and annotations", func(t *testing.T) {
@@ -317,7 +316,7 @@ func TestWriteReference(t *testing.T) {
 		ref := ginternals.NewSymbolicReference("H EAD", "refs/heads/master")
 		err = b.WriteReference(ref)
 		require.Error(t, err)
-		require.True(t, xerrors.Is(err, ginternals.ErrRefNameInvalid), "unexpected error")
+		require.True(t, errors.Is(err, ginternals.ErrRefNameInvalid), "unexpected error")
 	})
 
 	t.Run("should pass overwriting a symbolic reference", func(t *testing.T) {
@@ -472,7 +471,7 @@ func TestWriteReferenceSafe(t *testing.T) {
 		ref := ginternals.NewSymbolicReference("H EAD", "refs/heads/master")
 		err = b.WriteReferenceSafe(ref)
 		require.Error(t, err)
-		require.True(t, xerrors.Is(err, ginternals.ErrRefNameInvalid), "unexpected error")
+		require.True(t, errors.Is(err, ginternals.ErrRefNameInvalid), "unexpected error")
 	})
 
 	t.Run("should fail overwritting a ref on disk", func(t *testing.T) {
@@ -501,7 +500,7 @@ func TestWriteReferenceSafe(t *testing.T) {
 		ref := ginternals.NewSymbolicReference("HEAD", "refs/heads/master")
 		err = b.WriteReferenceSafe(ref)
 		require.Error(t, err)
-		require.True(t, xerrors.Is(err, ginternals.ErrRefExists), "unexpected error")
+		require.True(t, errors.Is(err, ginternals.ErrRefExists), "unexpected error")
 
 		// let's make sure the data have not changed
 		data, err = os.ReadFile(filepath.Join(b.Path(), "HEAD"))
@@ -534,7 +533,7 @@ func TestWriteReferenceSafe(t *testing.T) {
 		ref := ginternals.NewSymbolicReference("refs/heads/master", "refs/heads/branch")
 		err = b.WriteReferenceSafe(ref)
 		require.Error(t, err)
-		require.True(t, xerrors.Is(err, ginternals.ErrRefExists), "unexpected error")
+		require.True(t, errors.Is(err, ginternals.ErrRefExists), "unexpected error")
 
 		// Let's make sure the data have not been persisted
 		_, err = os.ReadFile(filepath.Join(b.Path(), "refs", "heads", "master"))

--- a/cmd/git-go/cat_file.go
+++ b/cmd/git-go/cat_file.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Nivl/git-go/ginternals"
 	"github.com/Nivl/git-go/ginternals/object"
 	"github.com/spf13/cobra"
-	"golang.org/x/xerrors"
 )
 
 var errBadFile = errors.New("bad file")
@@ -103,12 +102,12 @@ func catFileCmd(out io.Writer, cfg *flags, p catFileParams) (err error) {
 
 			// if the ref doesn't exist we test the the next one
 			if !errors.Is(err, ginternals.ErrRefNotFound) {
-				return xerrors.Errorf("could not check if ref %s exists: %w", refName, err)
+				return fmt.Errorf("could not check if ref %s exists: %w", refName, err)
 			}
 		}
 
 		if oid.IsZero() {
-			return xerrors.Errorf("not a valid object name %s", p.objectName)
+			return fmt.Errorf("not a valid object name %s", p.objectName)
 		}
 	}
 
@@ -120,11 +119,11 @@ func catFileCmd(out io.Writer, cfg *flags, p catFileParams) (err error) {
 	if p.typ != "" {
 		_, err = object.NewTypeFromString(p.typ)
 		if err != nil {
-			return xerrors.Errorf("%s: %w", p.typ, err)
+			return fmt.Errorf("%s: %w", p.typ, err)
 		}
 
 		if o.Type().String() != p.typ {
-			return xerrors.Errorf("%s: %w", p.objectName, errBadFile)
+			return fmt.Errorf("%s: %w", p.objectName, errBadFile)
 		}
 	}
 
@@ -138,7 +137,7 @@ func catFileCmd(out io.Writer, cfg *flags, p catFileParams) (err error) {
 		case object.TypeCommit:
 			c, err := o.AsCommit()
 			if err != nil {
-				return xerrors.Errorf("could not get commit %w", err)
+				return fmt.Errorf("could not get commit %w", err)
 			}
 			fmt.Fprintf(out, "tree %s\n", c.TreeID().String())
 			for _, id := range c.ParentIDs() {
@@ -154,7 +153,7 @@ func catFileCmd(out io.Writer, cfg *flags, p catFileParams) (err error) {
 		case object.TypeTag:
 			tag, err := o.AsTag()
 			if err != nil {
-				return xerrors.Errorf("could not get tag %w", err)
+				return fmt.Errorf("could not get tag %w", err)
 			}
 			fmt.Fprintf(out, "object %s\n", tag.Target().String())
 			fmt.Fprintf(out, "type %s\n", tag.Type().String())
@@ -168,7 +167,7 @@ func catFileCmd(out io.Writer, cfg *flags, p catFileParams) (err error) {
 		case object.TypeTree:
 			tree, err := o.AsTree()
 			if err != nil {
-				return xerrors.Errorf("could not get tree %w", err)
+				return fmt.Errorf("could not get tree %w", err)
 			}
 			for _, e := range tree.Entries() {
 				fmt.Fprintf(out, "%06o %s %s\t%s\n", e.Mode, e.Mode.ObjectType().String(), e.ID.String(), e.Path)
@@ -178,7 +177,7 @@ func catFileCmd(out io.Writer, cfg *flags, p catFileParams) (err error) {
 		case object.ObjectDeltaOFS, object.ObjectDeltaRef:
 			fallthrough
 		default:
-			return xerrors.Errorf("pretty-print not supported for type %s", o.Type().String())
+			return fmt.Errorf("pretty-print not supported for type %s", o.Type().String())
 		}
 	default:
 		fmt.Fprint(out, string(o.Bytes()))

--- a/cmd/git-go/hash_object.go
+++ b/cmd/git-go/hash_object.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Nivl/git-go/ginternals/object"
 	"github.com/spf13/cobra"
-	"golang.org/x/xerrors"
 )
 
 func newHashObjectCmd() *cobra.Command {
@@ -40,18 +39,18 @@ func hashObjectCmd(out io.Writer, filePath, typ string) error {
 		o = object.New(object.TypeCommit, content)
 		_, err = o.AsCommit()
 		if err != nil {
-			return xerrors.Errorf("invalid commit file: %w", err)
+			return fmt.Errorf("invalid commit file: %w", err)
 		}
 	case object.TypeTree.String():
 		o = object.New(object.TypeTree, content)
 		_, err = o.AsTree()
 		if err != nil {
-			return xerrors.Errorf("invalid tree file: %w", err)
+			return fmt.Errorf("invalid tree file: %w", err)
 		}
 	case object.TypeTag.String():
 		fallthrough
 	default:
-		return xerrors.Errorf("unsupported object type %s", typ)
+		return fmt.Errorf("unsupported object type %s", typ)
 	}
 
 	_, err = o.Compress()

--- a/cmd/git-go/helpers.go
+++ b/cmd/git-go/helpers.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"fmt"
+
 	git "github.com/Nivl/git-go"
 	"github.com/Nivl/git-go/ginternals/config"
-	"golang.org/x/xerrors"
 )
 
 func loadRepository(cfg *flags) (*git.Repository, error) {
@@ -14,7 +15,7 @@ func loadRepository(cfg *flags) (*git.Repository, error) {
 		IsBare:           cfg.Bare,
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("could not create param: %w", err)
+		return nil, fmt.Errorf("could not create param: %w", err)
 	}
 
 	// run the command

--- a/cmd/git-go/init.go
+++ b/cmd/git-go/init.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"fmt"
+
 	git "github.com/Nivl/git-go"
 	"github.com/Nivl/git-go/ginternals/config"
 	"github.com/spf13/cobra"
-	"golang.org/x/xerrors"
 )
 
 func newInitCmd(cfg *flags) *cobra.Command {
@@ -29,7 +30,7 @@ func initCmd(cfg *flags) error {
 		SkipGitDirLookUp: true,
 	})
 	if err != nil {
-		return xerrors.Errorf("could not create param: %w", err)
+		return fmt.Errorf("could not create param: %w", err)
 	}
 
 	r, err := git.InitRepositoryWithParams(p, git.InitOptions{

--- a/ginternals/config/env.go
+++ b/ginternals/config/env.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,7 +10,6 @@ import (
 	"github.com/Nivl/git-go/env"
 	"github.com/Nivl/git-go/internal/gitpath"
 	"github.com/Nivl/git-go/internal/pathutil"
-	"golang.org/x/xerrors"
 )
 
 // ErrNoWorkTreeAlone is thrown when a work tree path is given without
@@ -118,7 +118,7 @@ func NewGitOptionsSkipEnv(opts NewGitParamsOptions) (*GitParams, error) {
 func setGitParams(p *GitParams, opts NewGitParamsOptions) (err error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return xerrors.Errorf("could not get the current directory: %w", err)
+		return fmt.Errorf("could not get the current directory: %w", err)
 	}
 	if opts.WorkingDirectory == "" {
 		opts.WorkingDirectory = wd
@@ -154,7 +154,7 @@ func setGitParams(p *GitParams, opts NewGitParamsOptions) (err error) {
 		if !opts.SkipGitDirLookUp {
 			guessedWorkingTree, err = pathutil.WorkingTreeFromPath(opts.WorkingDirectory)
 			if err != nil {
-				return xerrors.Errorf("could not find working tree: %w", err)
+				return fmt.Errorf("could not find working tree: %w", err)
 			}
 		}
 		p.GitDirPath = filepath.Join(guessedWorkingTree, gitpath.DotGitPath)

--- a/ginternals/object/object.go
+++ b/ginternals/object/object.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Nivl/git-go/ginternals"
 	"github.com/Nivl/git-go/internal/errutil"
-	"golang.org/x/xerrors"
 )
 
 var (
@@ -187,7 +186,7 @@ func (o *Object) Compress() (data []byte, err error) {
 	defer errutil.Close(zw, &err)
 
 	if _, err = zw.Write(fileContent); err != nil {
-		return nil, xerrors.Errorf("could not zlib the object: %w", err)
+		return nil, fmt.Errorf("could not zlib the object: %w", err)
 	}
 	return compressedContent.Bytes(), nil
 }

--- a/ginternals/object/tag.go
+++ b/ginternals/object/tag.go
@@ -2,10 +2,10 @@ package object
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/Nivl/git-go/ginternals"
 	"github.com/Nivl/git-go/internal/readutil"
-	"golang.org/x/xerrors"
 )
 
 // TagParams represents all the data needed to create a Tag
@@ -64,7 +64,7 @@ func NewTag(p *TagParams) *Tag {
 // - The gpgsig is optional
 func NewTagFromObject(o *Object) (*Tag, error) {
 	if o.typ != TypeTag {
-		return nil, xerrors.Errorf("type %s is not a tag: %w", o.typ, ErrObjectInvalid)
+		return nil, fmt.Errorf("type %s is not a tag: %w", o.typ, ErrObjectInvalid)
 	}
 	tag := &Tag{
 		id:        o.ID(),
@@ -79,7 +79,7 @@ func NewTagFromObject(o *Object) (*Tag, error) {
 
 		// If we didn't find anything then something is wrong
 		if len(line) == 0 && offset == 1 {
-			return nil, xerrors.Errorf("could not find tag first line: %w", ErrTagInvalid)
+			return nil, fmt.Errorf("could not find tag first line: %w", ErrTagInvalid)
 		}
 
 		// if we got an empty line, it means everything from now to the end
@@ -97,17 +97,17 @@ func NewTagFromObject(o *Object) (*Tag, error) {
 		case "object":
 			tag.target, err = ginternals.NewOidFromChars(kv[1])
 			if err != nil {
-				return nil, xerrors.Errorf("could not parse target id %#v: %w", kv[1], err)
+				return nil, fmt.Errorf("could not parse target id %#v: %w", kv[1], err)
 			}
 		case "type":
 			tag.typ, err = NewTypeFromString(string(kv[1]))
 			if err != nil {
-				return nil, xerrors.Errorf("invalid object type %s: %w", string(kv[1]), err)
+				return nil, fmt.Errorf("invalid object type %s: %w", string(kv[1]), err)
 			}
 		case "tagger":
 			tag.tagger, err = NewSignatureFromBytes(kv[1])
 			if err != nil {
-				return nil, xerrors.Errorf("could not parse tagger [%s]: %w", string(kv[1]), err)
+				return nil, fmt.Errorf("could not parse tagger [%s]: %w", string(kv[1]), err)
 			}
 		case "tag":
 			tag.tag = string(kv[1])
@@ -122,13 +122,13 @@ func NewTagFromObject(o *Object) (*Tag, error) {
 
 	// validate the tag
 	if tag.tagger.IsZero() {
-		return nil, xerrors.Errorf("tag has no tagger: %w", ErrTagInvalid)
+		return nil, fmt.Errorf("tag has no tagger: %w", ErrTagInvalid)
 	}
 	if tag.target.IsZero() {
-		return nil, xerrors.Errorf("tag has no target: %w", ErrTagInvalid)
+		return nil, fmt.Errorf("tag has no target: %w", ErrTagInvalid)
 	}
 	if !tag.typ.IsValid() {
-		return nil, xerrors.Errorf("tag has no type: %w", ErrTagInvalid)
+		return nil, fmt.Errorf("tag has no type: %w", ErrTagInvalid)
 	}
 
 	return tag, nil

--- a/ginternals/object/tree.go
+++ b/ginternals/object/tree.go
@@ -2,11 +2,11 @@ package object
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 
 	"github.com/Nivl/git-go/ginternals"
 	"github.com/Nivl/git-go/internal/readutil"
-	"golang.org/x/xerrors"
 )
 
 // TreeObjectMode represents the mode of an object inside a tree
@@ -86,7 +86,7 @@ func NewTree(entries []TreeEntry) *Tree {
 // - a Tree may have multiple entries
 func NewTreeFromObject(o *Object) (*Tree, error) {
 	if o.Type() != TypeTree {
-		return nil, xerrors.Errorf("type %s is not a tree: %w", o.typ, ErrObjectInvalid)
+		return nil, fmt.Errorf("type %s is not a tree: %w", o.typ, ErrObjectInvalid)
 	}
 
 	entries := []TreeEntry{}
@@ -100,30 +100,30 @@ func NewTreeFromObject(o *Object) (*Tree, error) {
 			entry := TreeEntry{}
 			data := readutil.ReadTo(objData[offset:], ' ')
 			if len(data) == 0 {
-				return nil, xerrors.Errorf("could not retrieve the mode of entry %d: %w", i, ErrTreeInvalid)
+				return nil, fmt.Errorf("could not retrieve the mode of entry %d: %w", i, ErrTreeInvalid)
 			}
 			offset += len(data) + 1 // +1 for the space
 			mode, err := strconv.ParseInt(string(data), 8, 32)
 			if err != nil {
-				return nil, xerrors.Errorf("could not parse mode of entry %d: %s: %w", i, err.Error(), ErrTreeInvalid)
+				return nil, fmt.Errorf("could not parse mode of entry %d: %s: %w", i, err.Error(), ErrTreeInvalid)
 			}
 			entry.Mode = TreeObjectMode(mode)
 
 			data = readutil.ReadTo(objData[offset:], 0)
 			if len(data) == 0 {
-				return nil, xerrors.Errorf("could not retrieve the path of entry %d: %w", i, ErrTreeInvalid)
+				return nil, fmt.Errorf("could not retrieve the path of entry %d: %w", i, ErrTreeInvalid)
 			}
 			offset += len(data) + 1 // +1 for the \0
 			entry.Path = string(data)
 
 			if offset+20 > len(objData) {
-				return nil, xerrors.Errorf("not enough space to retrieve the ID of entry %d: %w", i, ErrTreeInvalid)
+				return nil, fmt.Errorf("not enough space to retrieve the ID of entry %d: %w", i, ErrTreeInvalid)
 			}
 			entry.ID, err = ginternals.NewOidFromHex(objData[offset : offset+20])
 			if err != nil {
 				// should never fail since any value is valid as long as it
 				// is 20 chars
-				return nil, xerrors.Errorf("invalid SHA for entry %d (%s): %w", i, err.Error(), ErrTreeInvalid)
+				return nil, fmt.Errorf("invalid SHA for entry %d (%s): %w", i, err.Error(), ErrTreeInvalid)
 			}
 			offset += 20
 

--- a/ginternals/oid_test.go
+++ b/ginternals/oid_test.go
@@ -1,13 +1,13 @@
 package ginternals_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/Nivl/git-go/ginternals"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestNewOidFromStr(t *testing.T) {
@@ -46,7 +46,7 @@ func TestNewOidFromStr(t *testing.T) {
 				require.Error(t, err)
 				assert.Equal(t, ginternals.NullOid, oid)
 				if tc.expectedError != nil {
-					assert.True(t, xerrors.Is(err, ginternals.ErrInvalidOid), "invalid error returned: %s", err.Error())
+					assert.True(t, errors.Is(err, ginternals.ErrInvalidOid), "invalid error returned: %s", err.Error())
 				}
 				return
 			}
@@ -92,7 +92,7 @@ func TestNewOidFromChars(t *testing.T) {
 				require.Error(t, err)
 				assert.Equal(t, ginternals.NullOid, oid)
 				if tc.expectedError != nil {
-					assert.True(t, xerrors.Is(err, ginternals.ErrInvalidOid), "invalid error returned: %s", err.Error())
+					assert.True(t, errors.Is(err, ginternals.ErrInvalidOid), "invalid error returned: %s", err.Error())
 				}
 				return
 			}
@@ -135,7 +135,7 @@ func TestNewOidFromHex(t *testing.T) {
 				require.Error(t, err)
 				assert.Equal(t, ginternals.NullOid, oid)
 				if tc.expectedError != nil {
-					assert.True(t, xerrors.Is(err, ginternals.ErrInvalidOid), "invalid error returned: %s", err.Error())
+					assert.True(t, errors.Is(err, ginternals.ErrInvalidOid), "invalid error returned: %s", err.Error())
 				}
 				return
 			}

--- a/ginternals/packfile/packfile.go
+++ b/ginternals/packfile/packfile.go
@@ -7,6 +7,7 @@ import (
 	"compress/zlib"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -17,7 +18,6 @@ import (
 	"github.com/Nivl/git-go/internal/cache"
 	"github.com/Nivl/git-go/internal/errutil"
 	"github.com/spf13/afero"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -106,7 +106,7 @@ type Pack struct {
 func NewFromFile(fs afero.Fs, filePath string) (pack *Pack, err error) {
 	f, err := fs.Open(filePath)
 	if err != nil {
-		return nil, xerrors.Errorf("could not open %s: %w", filePath, err)
+		return nil, fmt.Errorf("could not open %s: %w", filePath, err)
 	}
 	defer func() {
 		if err != nil {
@@ -116,7 +116,7 @@ func NewFromFile(fs afero.Fs, filePath string) (pack *Pack, err error) {
 
 	c, err := cache.NewLRU(1000)
 	if err != nil {
-		return nil, xerrors.Errorf("could not create LRU cache: %w", err)
+		return nil, fmt.Errorf("could not create LRU cache: %w", err)
 	}
 	p := &Pack{
 		r:               f,
@@ -126,34 +126,34 @@ func NewFromFile(fs afero.Fs, filePath string) (pack *Pack, err error) {
 	// Let's validate the header
 	_, err = f.ReadAt(p.header[:], 0)
 	if err != nil {
-		return nil, xerrors.Errorf("could read header of packfile: %w", err)
+		return nil, fmt.Errorf("could read header of packfile: %w", err)
 	}
 	if !bytes.Equal(p.header[0:4], packfileMagic()) {
-		return nil, xerrors.Errorf("invalid header: %w", ErrInvalidMagic)
+		return nil, fmt.Errorf("invalid header: %w", ErrInvalidMagic)
 	}
 	if !bytes.Equal(p.header[4:8], packfileVersion()) {
-		return nil, xerrors.Errorf("invalid header: %w", ErrInvalidVersion)
+		return nil, fmt.Errorf("invalid header: %w", ErrInvalidVersion)
 	}
 
 	// Let's find the ID of the packfile (last element of the file)
 	id := make([]byte, ginternals.OidSize)
 	offset, err := f.Seek(-ginternals.OidSize, os.SEEK_END)
 	if err != nil {
-		return nil, xerrors.Errorf("could not get to the offset of the ID: %w", err)
+		return nil, fmt.Errorf("could not get to the offset of the ID: %w", err)
 	}
 	if _, err = f.ReadAt(id, offset); err != nil {
-		return nil, xerrors.Errorf("could not read the ID: %w", err)
+		return nil, fmt.Errorf("could not read the ID: %w", err)
 	}
 	p.id, err = ginternals.NewOidFromHex(id)
 	if err != nil {
-		return nil, xerrors.Errorf("could not generate oid from %v: %w", id, err)
+		return nil, fmt.Errorf("could not generate oid from %v: %w", id, err)
 	}
 
 	// Now we load the index file
 	indexFilePath := strings.TrimSuffix(filePath, ExtPackfile) + ExtIndex
 	p.idxFile, err = os.Open(indexFilePath)
 	if err != nil {
-		return nil, xerrors.Errorf("could not open %s: %w", indexFilePath, err)
+		return nil, fmt.Errorf("could not open %s: %w", indexFilePath, err)
 	}
 	defer func() {
 		if err != nil {
@@ -162,7 +162,7 @@ func NewFromFile(fs afero.Fs, filePath string) (pack *Pack, err error) {
 	}()
 	p.idx, err = NewIndex(bufio.NewReader(p.idxFile))
 	if err != nil {
-		return nil, xerrors.Errorf("could create index for %s: %w", indexFilePath, err)
+		return nil, fmt.Errorf("could create index for %s: %w", indexFilePath, err)
 	}
 
 	return p, nil
@@ -173,7 +173,7 @@ func NewFromFile(fs afero.Fs, filePath string) (pack *Pack, err error) {
 func (pck *Pack) getRawObjectAt(objectOffset uint64) (o *object.Object, deltaBaseSHA ginternals.Oid, deltaBaseOffset uint64, err error) {
 	_, err = pck.r.Seek(int64(objectOffset), io.SeekStart)
 	if err != nil {
-		return nil, ginternals.NullOid, 0, xerrors.Errorf("could not seek from 0 to object offset %d: %w", objectOffset, err)
+		return nil, ginternals.NullOid, 0, fmt.Errorf("could not seek from 0 to object offset %d: %w", objectOffset, err)
 	}
 	buf := bufio.NewReader(pck.r)
 
@@ -200,7 +200,7 @@ func (pck *Pack) getRawObjectAt(objectOffset uint64) (o *object.Object, deltaBas
 	// Total: 10 bytes
 	metadata, err := buf.Peek(10)
 	if err != nil {
-		return nil, ginternals.NullOid, 0, xerrors.Errorf("could not get object meta: %w", err)
+		return nil, ginternals.NullOid, 0, fmt.Errorf("could not get object meta: %w", err)
 	}
 
 	// We now need to extract the type of the object. The type is a number
@@ -213,7 +213,7 @@ func (pck *Pack) getRawObjectAt(objectOffset uint64) (o *object.Object, deltaBas
 	// >> 4        : 0000_0TTT
 	objectType := object.Type((metadata[0] & 0b_0111_0000) >> 4)
 	if !objectType.IsValid() {
-		return nil, ginternals.NullOid, 0, xerrors.Errorf("unknown object type %d", objectType)
+		return nil, ginternals.NullOid, 0, fmt.Errorf("unknown object type %d", objectType)
 	}
 
 	// The first part of the size is on the last 4 bits of the byte.
@@ -228,7 +228,7 @@ func (pck *Pack) getRawObjectAt(objectOffset uint64) (o *object.Object, deltaBas
 	if pck.isMSBSet(metadata[0]) {
 		size, byteRead, err := pck.readSize(metadata[1:])
 		if err != nil {
-			return nil, ginternals.NullOid, 0, xerrors.Errorf("couldn't read object size: %w", err)
+			return nil, ginternals.NullOid, 0, fmt.Errorf("couldn't read object size: %w", err)
 		}
 		metadataSize += byteRead
 		// we add 4bits to the right of $size, then we merge everything with |
@@ -243,7 +243,7 @@ func (pck *Pack) getRawObjectAt(objectOffset uint64) (o *object.Object, deltaBas
 	// size), we now need to discard the right amount of bytes to move
 	// our internal cursor to the object data
 	if _, err = buf.Discard(metadataSize); err != nil {
-		return nil, ginternals.NullOid, 0, xerrors.Errorf("could not skip the metadata: %w", err)
+		return nil, ginternals.NullOid, 0, fmt.Errorf("could not skip the metadata: %w", err)
 	}
 
 	// Some objects are deltified and need extra parsing before getting to
@@ -260,11 +260,11 @@ func (pck *Pack) getRawObjectAt(objectOffset uint64) (o *object.Object, deltaBas
 		baseObjectSHA := make([]byte, ginternals.OidSize)
 		_, err = buf.Read(baseObjectSHA)
 		if err != nil {
-			return nil, ginternals.NullOid, 0, xerrors.Errorf("could not get base object SHA: %w", err)
+			return nil, ginternals.NullOid, 0, fmt.Errorf("could not get base object SHA: %w", err)
 		}
 		baseObjectOid, err = ginternals.NewOidFromHex(baseObjectSHA)
 		if err != nil {
-			return nil, ginternals.NullOid, 0, xerrors.Errorf("could not parse base object SHA %#v: %w", baseObjectSHA, err)
+			return nil, ginternals.NullOid, 0, fmt.Errorf("could not parse base object SHA %#v: %w", baseObjectSHA, err)
 		}
 	case object.ObjectDeltaOFS:
 		// we're assuming the offset is no bigger than 9 bytes to fit an int64.
@@ -272,11 +272,11 @@ func (pck *Pack) getRawObjectAt(objectOffset uint64) (o *object.Object, deltaBas
 		// so we need to read an extra byte
 		offsetParts, err := buf.Peek(9)
 		if err != nil {
-			return nil, ginternals.NullOid, 0, xerrors.Errorf("could not get base object offset: %w", err)
+			return nil, ginternals.NullOid, 0, fmt.Errorf("could not get base object offset: %w", err)
 		}
 		offset, bytesRead, err := pck.readDeltaOffset(offsetParts)
 		if err != nil {
-			return nil, ginternals.NullOid, 0, xerrors.Errorf("couldn't read base object offset: %w", err)
+			return nil, ginternals.NullOid, 0, fmt.Errorf("couldn't read base object offset: %w", err)
 		}
 		baseObjectOffset = objectOffset - offset
 
@@ -284,25 +284,25 @@ func (pck *Pack) getRawObjectAt(objectOffset uint64) (o *object.Object, deltaBas
 		// now need to discard the right amount of bytes to move our internal
 		// cursor to the object data
 		if _, err = buf.Discard(bytesRead); err != nil {
-			return nil, ginternals.NullOid, 0, xerrors.Errorf("could not skip the offset: %w", err)
+			return nil, ginternals.NullOid, 0, fmt.Errorf("could not skip the offset: %w", err)
 		}
 	}
 
 	// We can now fetch the actual data of the object, which is zlib encoded
 	zlibR, err := zlib.NewReader(buf)
 	if err != nil {
-		return nil, ginternals.NullOid, 0, xerrors.Errorf("could not get zlib reader: %w", err)
+		return nil, ginternals.NullOid, 0, fmt.Errorf("could not get zlib reader: %w", err)
 	}
 	defer errutil.Close(zlibR, &err)
 
 	objectData := bytes.Buffer{}
 	_, err = io.Copy(&objectData, zlibR)
 	if err != nil {
-		return nil, ginternals.NullOid, 0, xerrors.Errorf("could not decompress: %w", err)
+		return nil, ginternals.NullOid, 0, fmt.Errorf("could not decompress: %w", err)
 	}
 
 	if objectData.Len() != int(objectSize) {
-		return nil, ginternals.NullOid, 0, xerrors.Errorf("object size not valid. expecting %d, got %d", objectSize, objectData.Len())
+		return nil, ginternals.NullOid, 0, fmt.Errorf("object size not valid. expecting %d, got %d", objectSize, objectData.Len())
 	}
 
 	return object.New(objectType, objectData.Bytes()), baseObjectOid, baseObjectOffset, nil
@@ -332,12 +332,12 @@ func (pck *Pack) getObjectAt(objectOffset uint64) (*object.Object, error) {
 	if !baseOid.IsZero() {
 		base, err = pck.getObject(baseOid)
 		if err != nil {
-			return nil, xerrors.Errorf("could not get base object %s: %w", baseOid.String(), err)
+			return nil, fmt.Errorf("could not get base object %s: %w", baseOid.String(), err)
 		}
 	} else {
 		base, err = pck.getObjectAt(baseOffset)
 		if err != nil {
-			return nil, xerrors.Errorf("could not get base object at offset %d: %w", baseOffset, err)
+			return nil, fmt.Errorf("could not get base object at offset %d: %w", baseOffset, err)
 		}
 	}
 
@@ -352,14 +352,14 @@ func (pck *Pack) getObjectAt(objectOffset uint64) (*object.Object, error) {
 	delta := o.Bytes()
 	sourceSize, sourceSizeLen, err := pck.readSize(delta)
 	if err != nil {
-		return nil, xerrors.Errorf("couldn't read source size of delta: %w", err)
+		return nil, fmt.Errorf("couldn't read source size of delta: %w", err)
 	}
 	if int(sourceSize) != base.Size() {
-		return nil, xerrors.Errorf("invalid base object size. expected %d, got %d: %w", base.Size(), sourceSize, err)
+		return nil, fmt.Errorf("invalid base object size. expected %d, got %d: %w", base.Size(), sourceSize, err)
 	}
 	_, tartgetSizeLen, err := pck.readSize(delta[sourceSizeLen:])
 	if err != nil {
-		return nil, xerrors.Errorf("couldn't read target size of delta: %w", err)
+		return nil, fmt.Errorf("couldn't read target size of delta: %w", err)
 	}
 	headerSize := tartgetSizeLen + sourceSizeLen
 	instructions := delta[headerSize:]
@@ -463,7 +463,7 @@ func (pck *Pack) getObject(oid ginternals.Oid) (*object.Object, error) {
 	objectOffset, err := pck.idx.GetObjectOffset(oid)
 	if err != nil {
 		if !errors.Is(err, ginternals.ErrObjectNotFound) {
-			return nil, xerrors.Errorf("could not get object index: %w", err)
+			return nil, fmt.Errorf("could not get object index: %w", err)
 		}
 		return nil, err
 	}
@@ -620,7 +620,7 @@ var OidWalkStop = errors.New("stop walking") //nolint // the linter expects all 
 // WalkOids walks over all the OIDs of the packfile
 func (pck *Pack) WalkOids(f OidWalkFunc) error {
 	if err := pck.idx.parse(); err != nil {
-		return xerrors.Errorf("could not get oids: %w", err)
+		return fmt.Errorf("could not get oids: %w", err)
 	}
 
 	for v := range pck.idx.hashOffset {

--- a/ginternals/packfile/packfile_test.go
+++ b/ginternals/packfile/packfile_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestNewFromFile(t *testing.T) {
@@ -46,7 +45,7 @@ func TestNewFromFile(t *testing.T) {
 		packFilePath := filepath.Join(repoPath, gitpath.DotGitPath, gitpath.ObjectsPath, gitpath.ObjectsPackPath, packFileName)
 		pack, err := packfile.NewFromFile(afero.NewOsFs(), packFilePath)
 		require.Error(t, err)
-		assert.True(t, xerrors.Is(err, packfile.ErrInvalidMagic))
+		assert.True(t, errors.Is(err, packfile.ErrInvalidMagic))
 		assert.Nil(t, pack)
 	})
 }

--- a/ginternals/packfile/packindex.go
+++ b/ginternals/packfile/packindex.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"sync"
 
@@ -182,7 +183,7 @@ func (idx *PackIndex) parse() (err error) {
 		// this should only happen if the indexfile is invalid and
 		// layer2 is smaller than it should
 		if currentOffset >= layer3offset {
-			return fmt.Errorf("oid %d is out of bound in layer2", i)
+			return fmt.Errorf("oid %d is out of bound in layer2: %w", i, os.ErrNotExist)
 		}
 
 		_, err = io.ReadFull(idx.r, bufOid)
@@ -229,7 +230,7 @@ func (idx *PackIndex) parse() (err error) {
 		// this should only happen if the indexfile is invalid and
 		// layer4 is smaller than it should
 		if currentOffset >= layer5Offset {
-			return fmt.Errorf("oid %s is out of bound in layer4", oid.String())
+			return fmt.Errorf("oid %s is out of bound in layer4: %w", oid.String(), os.ErrNotExist)
 		}
 		_, err = io.ReadFull(idx.r, bufInt32)
 		if err != nil {
@@ -276,7 +277,7 @@ func (idx *PackIndex) parse() (err error) {
 		// This should never happen since the offsert should be back-
 		// to-back, but it cost nothing to double check
 		if data.relativeOffset != currentRelativeOffset {
-			return fmt.Errorf("expected oid %s to be at (relative) offset %d, but is at %d instead (in layer5 %d)", data.oid.String(), currentRelativeOffset, data.relativeOffset, layer5Offset)
+			return fmt.Errorf("expected oid %s to be at (relative) offset %d, but is at %d instead (in layer5 %d): %w", data.oid.String(), currentRelativeOffset, data.relativeOffset, layer5Offset, os.ErrNotExist)
 		}
 
 		entryOffset := layer5Offset + int64(data.relativeOffset)

--- a/ginternals/packfile/packindex.go
+++ b/ginternals/packfile/packindex.go
@@ -3,13 +3,13 @@ package packfile
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"sort"
 	"sync"
 
 	"github.com/Nivl/git-go/ginternals"
 	"github.com/Nivl/git-go/internal/readutil"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -100,10 +100,10 @@ func NewIndex(r readutil.BufferedReader) (idx *PackIndex, err error) {
 	header := make([]byte, len(indexHeader()))
 	_, err = r.Read(header)
 	if err != nil {
-		return nil, xerrors.Errorf("could read header of index file: %w", err)
+		return nil, fmt.Errorf("could read header of index file: %w", err)
 	}
 	if !bytes.Equal(header, indexHeader()) {
-		return nil, xerrors.Errorf("invalid header: %w", ErrInvalidMagic)
+		return nil, fmt.Errorf("invalid header: %w", ErrInvalidMagic)
 	}
 
 	return &PackIndex{
@@ -115,7 +115,7 @@ func NewIndex(r readutil.BufferedReader) (idx *PackIndex, err error) {
 // If the object is not found ginternals.ErrObjectNotFound is returned
 func (idx *PackIndex) GetObjectOffset(oid ginternals.Oid) (uint64, error) {
 	if err := idx.parse(); err != nil {
-		return 0, xerrors.Errorf("could not parse the index file: %w", err)
+		return 0, fmt.Errorf("could not parse the index file: %w", err)
 	}
 	offset, exists := idx.hashOffset[oid]
 	if !exists {
@@ -158,12 +158,12 @@ func (idx *PackIndex) parse() (err error) {
 	// We move the pointer to the data we need
 	_, err = idx.r.Discard(lastEntryRelOffset)
 	if err != nil {
-		return xerrors.Errorf("could not move pointer to the last entry of layer1: %w", err)
+		return fmt.Errorf("could not move pointer to the last entry of layer1: %w", err)
 	}
 	// we now can read the count
 	_, err = io.ReadFull(idx.r, bufInt32)
 	if err != nil {
-		return xerrors.Errorf("couldn't get the total number of objects: %w", err)
+		return fmt.Errorf("couldn't get the total number of objects: %w", err)
 	}
 	objectCount := int(binary.BigEndian.Uint32(bufInt32))
 
@@ -182,16 +182,16 @@ func (idx *PackIndex) parse() (err error) {
 		// this should only happen if the indexfile is invalid and
 		// layer2 is smaller than it should
 		if currentOffset >= layer3offset {
-			return xerrors.Errorf("oid %d is out of bound in layer2", i)
+			return fmt.Errorf("oid %d is out of bound in layer2", i)
 		}
 
 		_, err = io.ReadFull(idx.r, bufOid)
 		if err != nil {
-			return xerrors.Errorf("couldn't get the oid at offset %d: %w", currentOffset, err)
+			return fmt.Errorf("couldn't get the oid at offset %d: %w", currentOffset, err)
 		}
 		oid, err := ginternals.NewOidFromHex(bufOid)
 		if err != nil {
-			return xerrors.Errorf("invalid oid at offset %d: %w", currentOffset, err)
+			return fmt.Errorf("invalid oid at offset %d: %w", currentOffset, err)
 		}
 		oids = append(oids, oid)
 	}
@@ -202,7 +202,7 @@ func (idx *PackIndex) parse() (err error) {
 	layer3Size := objectCount * layer3EntrySize
 	_, err = idx.r.Discard(layer3Size)
 	if err != nil {
-		return xerrors.Errorf("could not skip layer3: %w", err)
+		return fmt.Errorf("could not skip layer3: %w", err)
 	}
 
 	// We can now allocate our final map (oid => offset) and fill it with the
@@ -229,11 +229,11 @@ func (idx *PackIndex) parse() (err error) {
 		// this should only happen if the indexfile is invalid and
 		// layer4 is smaller than it should
 		if currentOffset >= layer5Offset {
-			return xerrors.Errorf("oid %s is out of bound in layer4", oid.String())
+			return fmt.Errorf("oid %s is out of bound in layer4", oid.String())
 		}
 		_, err = io.ReadFull(idx.r, bufInt32)
 		if err != nil {
-			return xerrors.Errorf("couldn't read offset of oid %s at position %d (layer4): %w", oid.String(), currentOffset, err)
+			return fmt.Errorf("couldn't read offset of oid %s at position %d (layer4): %w", oid.String(), currentOffset, err)
 		}
 		entry := binary.BigEndian.Uint32(bufInt32)
 
@@ -276,13 +276,13 @@ func (idx *PackIndex) parse() (err error) {
 		// This should never happen since the offsert should be back-
 		// to-back, but it cost nothing to double check
 		if data.relativeOffset != currentRelativeOffset {
-			return xerrors.Errorf("expected oid %s to be at (relative) offset %d, but is at %d instead (in layer5 %d)", data.oid.String(), currentRelativeOffset, data.relativeOffset, layer5Offset)
+			return fmt.Errorf("expected oid %s to be at (relative) offset %d, but is at %d instead (in layer5 %d)", data.oid.String(), currentRelativeOffset, data.relativeOffset, layer5Offset)
 		}
 
 		entryOffset := layer5Offset + int64(data.relativeOffset)
 		_, err = io.ReadFull(idx.r, bufInt64)
 		if err != nil {
-			return xerrors.Errorf("couldn't read offset of oid %s at position %d (layer5): %w", data.oid.String(), entryOffset, err)
+			return fmt.Errorf("couldn't read offset of oid %s at position %d (layer5): %w", data.oid.String(), entryOffset, err)
 		}
 		offset := binary.BigEndian.Uint64(bufInt64)
 		idx.hashOffset[data.oid] = offset

--- a/ginternals/packfile/packindex_test.go
+++ b/ginternals/packfile/packindex_test.go
@@ -2,6 +2,7 @@ package packfile_test
 
 import (
 	"bufio"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,7 +13,6 @@ import (
 	"github.com/Nivl/git-go/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestNewIndex(t *testing.T) {
@@ -54,7 +54,7 @@ func TestNewIndex(t *testing.T) {
 		index, err := packfile.NewIndex(bufio.NewReader(f))
 		require.Error(t, err)
 		assert.Nil(t, index)
-		assert.True(t, xerrors.Is(err, packfile.ErrInvalidMagic))
+		assert.True(t, errors.Is(err, packfile.ErrInvalidMagic))
 	})
 }
 
@@ -96,7 +96,7 @@ func TestGetObjectOffset(t *testing.T) {
 			require.NoError(t, err)
 			_, err = index.GetObjectOffset(oid)
 			require.Error(t, err)
-			require.True(t, xerrors.Is(err, ginternals.ErrObjectNotFound), "invalid error returned: %s", err.Error())
+			require.True(t, errors.Is(err, ginternals.ErrObjectNotFound), "invalid error returned: %s", err.Error())
 		})
 	})
 }

--- a/ginternals/reference.go
+++ b/ginternals/reference.go
@@ -3,9 +3,8 @@ package ginternals
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"strings"
-
-	"golang.org/x/xerrors"
 )
 
 // Common ref names
@@ -96,12 +95,12 @@ func resolveRefs(name string, finder RefContent, visited map[string]struct{}) (*
 	// Ex: refs/heads/master is a ref to refs/heads/a which is a ref to
 	// refs/heads/master
 	if _, ok := visited[name]; ok {
-		return nil, xerrors.Errorf("circular symbolic reference: %w", ErrRefInvalid)
+		return nil, fmt.Errorf("circular symbolic reference: %w", ErrRefInvalid)
 	}
 	visited[name] = struct{}{}
 
 	if !IsRefNameValid(name) {
-		return nil, xerrors.Errorf(`ref "%s": %w`, name, ErrRefNameInvalid)
+		return nil, fmt.Errorf(`ref "%s": %w`, name, ErrRefNameInvalid)
 	}
 
 	data, err := finder(name)

--- a/ginternals/reference_test.go
+++ b/ginternals/reference_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestIsRefNameValid(t *testing.T) {
@@ -197,7 +196,7 @@ func TestResolveReference(t *testing.T) {
 		ref, err := ResolveReference("HEAD", finder)
 		require.Error(t, err)
 		assert.Nil(t, ref)
-		assert.True(t, xerrors.Is(err, ErrRefInvalid), "invalid error returned")
+		assert.True(t, errors.Is(err, ErrRefInvalid), "invalid error returned")
 	})
 
 	t.Run("should fail op invalid name", func(t *testing.T) {
@@ -214,7 +213,7 @@ func TestResolveReference(t *testing.T) {
 		ref, err := ResolveReference("HEAD", finder)
 		require.Error(t, err)
 		assert.Nil(t, ref)
-		assert.True(t, xerrors.Is(err, ErrRefNameInvalid), "invalid error returned")
+		assert.True(t, errors.Is(err, ErrRefNameInvalid), "invalid error returned")
 	})
 
 	t.Run("should fail on invalid content", func(t *testing.T) {
@@ -231,7 +230,7 @@ func TestResolveReference(t *testing.T) {
 		ref, err := ResolveReference("HEAD", finder)
 		require.Error(t, err)
 		assert.Nil(t, ref)
-		assert.True(t, xerrors.Is(err, ErrRefInvalid), "invalid error returned")
+		assert.True(t, errors.Is(err, ErrRefInvalid), "invalid error returned")
 	})
 
 	t.Run("should fail on empty file", func(t *testing.T) {
@@ -248,7 +247,7 @@ func TestResolveReference(t *testing.T) {
 		ref, err := ResolveReference("HEAD", finder)
 		require.Error(t, err)
 		assert.Nil(t, ref)
-		assert.True(t, xerrors.Is(err, ErrRefInvalid), "invalid error returned")
+		assert.True(t, errors.Is(err, ErrRefInvalid), "invalid error returned")
 	})
 
 	t.Run("should pass error down from the finder", func(t *testing.T) {
@@ -261,7 +260,7 @@ func TestResolveReference(t *testing.T) {
 		ref, err := ResolveReference("HEAD", finder)
 		require.Error(t, err)
 		assert.Nil(t, ref)
-		assert.True(t, xerrors.Is(err, expectedErr), "invalid error returned")
+		assert.True(t, errors.Is(err, expectedErr), "invalid error returned")
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/ini.v1 v1.62.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,6 @@ golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/internal/pathutil/path_value.go
+++ b/internal/pathutil/path_value.go
@@ -21,6 +21,18 @@ const (
 	PathValueTypeAny
 )
 
+var (
+	// ErrIsDirectory is an error returned when a path
+	// points to a directory instead of a file
+	ErrIsDirectory = errors.New("path is a directory")
+	// ErrIsNotDirectory is an error returned when a path
+	// is expected to points to a directory but isn't
+	ErrIsNotDirectory = errors.New("path is not a directory")
+	// ErrUnknownType is an error returned when an unknown PathValueType
+	// is provided to a method
+	ErrUnknownType = errors.New("type unknown")
+)
+
 // PathValue represents a Flag value to be parsed by spf13/pflag
 type PathValue struct {
 	defaultValue  string
@@ -101,15 +113,15 @@ func (v *PathValue) Set(value string) (err error) {
 		switch v.typ {
 		case PathValueTypeFile:
 			if info.IsDir() {
-				return fmt.Errorf("invalid path %s: is a directory", value)
+				return fmt.Errorf("invalid path %s: %w", value, ErrIsDirectory)
 			}
 		case PathValueTypeDir:
 			if !info.IsDir() {
-				return fmt.Errorf("invalid path %s: not a directory", value)
+				return fmt.Errorf("invalid path %s: %w", value, ErrIsNotDirectory)
 			}
 		case PathValueTypeAny:
 		default:
-			return fmt.Errorf("invalid type: %d", v.typ)
+			return fmt.Errorf("type %d: %w", v.typ, ErrUnknownType)
 		}
 	}
 

--- a/internal/pathutil/path_value.go
+++ b/internal/pathutil/path_value.go
@@ -1,11 +1,12 @@
 package pathutil
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/pflag"
-	"golang.org/x/xerrors"
 )
 
 // PathValueType represents the type of a path
@@ -84,31 +85,31 @@ func (v *PathValue) Set(value string) (err error) {
 	}
 	value, err = filepath.Abs(value)
 	if err != nil {
-		return xerrors.Errorf("could not find absolute path: %w", err)
+		return fmt.Errorf("could not find absolute path: %w", err)
 	}
 
 	info, err := os.Stat(value)
-	if err != nil && !xerrors.Is(err, os.ErrNotExist) {
-		return xerrors.Errorf("could not check path %s: %w", value, err)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("could not check path %s: %w", value, err)
 	}
 
-	if v.pathMustExist && xerrors.Is(err, os.ErrNotExist) {
-		return xerrors.Errorf("invalid path %s: %w", value, os.ErrNotExist)
+	if v.pathMustExist && errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("invalid path %s: %w", value, os.ErrNotExist)
 	}
 
 	if info != nil {
 		switch v.typ {
 		case PathValueTypeFile:
 			if info.IsDir() {
-				return xerrors.Errorf("invalid path %s: is a directory", value)
+				return fmt.Errorf("invalid path %s: is a directory", value)
 			}
 		case PathValueTypeDir:
 			if !info.IsDir() {
-				return xerrors.Errorf("invalid path %s: not a directory", value)
+				return fmt.Errorf("invalid path %s: not a directory", value)
 			}
 		case PathValueTypeAny:
 		default:
-			return xerrors.Errorf("invalid type: %d", v.typ)
+			return fmt.Errorf("invalid type: %d", v.typ)
 		}
 	}
 

--- a/internal/pathutil/working_tree.go
+++ b/internal/pathutil/working_tree.go
@@ -2,11 +2,11 @@ package pathutil
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/Nivl/git-go/internal/gitpath"
-	"golang.org/x/xerrors"
 )
 
 // ErrNoRepo is an error returned when no repo are found
@@ -16,7 +16,7 @@ var ErrNoRepo = errors.New("not a git repository (or any of the parent directori
 func WorkingTree() (path string, err error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return "", xerrors.Errorf("could not get current working directory: %w", err)
+		return "", fmt.Errorf("could not get current working directory: %w", err)
 	}
 	return WorkingTreeFromPath(wd)
 }

--- a/repo.go
+++ b/repo.go
@@ -21,6 +21,7 @@ var (
 	ErrRepositoryExists             = errors.New("repository already exists")
 	ErrTagNotFound                  = errors.New("tag not found")
 	ErrTagExists                    = errors.New("tag already exists")
+	ErrNotADirectory                = errors.New("not a directory")
 )
 
 // Repository represent a git repository
@@ -110,7 +111,7 @@ func InitRepositoryWithParams(params *config.GitParams, opts InitOptions) (r *Re
 		switch err { //nolint:errorlint // we only want nil or not nil
 		case nil:
 			if !info.IsDir() {
-				return nil, fmt.Errorf("invalid path: not a directory")
+				return nil, fmt.Errorf("invalid path: %w", ErrNotADirectory)
 			}
 		default:
 			if !errors.Is(err, os.ErrNotExist) {
@@ -318,7 +319,7 @@ func (r *Repository) NewCommit(refname string, tree *object.Tree, author object.
 			return nil, fmt.Errorf("could not retrieve parent %s: %w", id.String(), err)
 		}
 		if parent.Type() != object.TypeCommit {
-			return nil, fmt.Errorf("invalid type for parent %s. got %d, expected %d", id.String(), parent.Type(), parent.Type())
+			return nil, fmt.Errorf("invalid type for parent %s. got %d, expected %d: %w", id.String(), parent.Type(), parent.Type(), object.ErrObjectInvalid)
 		}
 	}
 

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -39,6 +39,7 @@ func (r *Repository) NewTreeBuilderFromTree(t *object.Tree) *TreeBuilder {
 // Insert inserts a new object in a tree
 func (tb *TreeBuilder) Insert(path string, oid ginternals.Oid, mode object.TreeObjectMode) error {
 	if !mode.IsValid() {
+		//nolint:goerr113 // no need to wrap the error, this would only be caused by a bug in the codebase
 		return fmt.Errorf("invalid mode %o", mode)
 	}
 

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -1,12 +1,12 @@
 package git
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/Nivl/git-go/backend"
 	"github.com/Nivl/git-go/ginternals"
 	"github.com/Nivl/git-go/ginternals/object"
-	"golang.org/x/xerrors"
 )
 
 // TreeBuilder is used to build trees
@@ -39,18 +39,18 @@ func (r *Repository) NewTreeBuilderFromTree(t *object.Tree) *TreeBuilder {
 // Insert inserts a new object in a tree
 func (tb *TreeBuilder) Insert(path string, oid ginternals.Oid, mode object.TreeObjectMode) error {
 	if !mode.IsValid() {
-		return xerrors.Errorf("invalid mode %o", mode)
+		return fmt.Errorf("invalid mode %o", mode)
 	}
 
 	o, err := tb.Backend.Object(oid)
 	if err != nil {
-		return xerrors.Errorf("cannot verify object: %w", err)
+		return fmt.Errorf("cannot verify object: %w", err)
 	}
 
 	// TODO(melvin):
 	// 2. gitlink?
 	if o.Type() != object.TypeBlob && o.Type() != object.TypeTree {
-		return xerrors.Errorf("unexpected object %s: %w", o.Type().String(), object.ErrObjectInvalid)
+		return fmt.Errorf("unexpected object %s: %w", o.Type().String(), object.ErrObjectInvalid)
 	}
 
 	e := object.TreeEntry{
@@ -93,7 +93,7 @@ func (tb *TreeBuilder) Write() (*object.Tree, error) {
 	t := object.NewTree(entries)
 	o := t.ToObject()
 	if _, err := tb.Backend.WriteObject(o); err != nil {
-		return nil, xerrors.Errorf("could not write the object to the odb: %w", err)
+		return nil, fmt.Errorf("could not write the object to the odb: %w", err)
 	}
 	return o.AsTree()
 }

--- a/tree_builder_test.go
+++ b/tree_builder_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,7 +13,6 @@ import (
 	"github.com/Nivl/git-go/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestTreeBuilderInsert(t *testing.T) {
@@ -67,7 +67,7 @@ func TestTreeBuilderInsert(t *testing.T) {
 				err = tb.Insert("somewhere", oid, object.ModeFile)
 				if tc.expectedError != nil {
 					require.Error(t, err)
-					assert.True(t, xerrors.Is(err, tc.expectedError))
+					assert.True(t, errors.Is(err, tc.expectedError))
 				} else {
 					require.NoError(t, err)
 					assert.Len(t, tb.entries, 1)


### PR DESCRIPTION
The idea was to use `xerrors` to have stacktraces. We never actually did anything with that, so for now we have no reasons to keep it.