### PR TITLE
feat: support most options for init

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,7 +95,7 @@ linters-settings:
       - opinionated
 
     disabled-checks:
-      - sloppyReassign
-      - emptyFallthrough
-      - octalLiteral
-      - hugeParam # disabled because we pass option objects by copy
+      - sloppyReassign # conflicts with no shadow
+      - emptyFallthrough # we use fallthrough to force a case to go to default while being explicit
+      - octalLiteral # we use raw octal everywhere
+      - hugeParam # disabled because we pass Option objects by copy

--- a/backend/config.go
+++ b/backend/config.go
@@ -14,7 +14,7 @@ func (b *Backend) loadConfig() error {
 
 // Init initializes a repository
 // This method cannot be called concurrently with other methods
-func (b *Backend) Init() error {
+func (b *Backend) Init(branchName string) error {
 	// Create the directories
 	dirs := []string{
 		b.Path(),
@@ -53,7 +53,7 @@ func (b *Backend) Init() error {
 		return fmt.Errorf("could not set the default config: %w", err)
 	}
 
-	ref := ginternals.NewSymbolicReference(ginternals.Head, ginternals.LocalBranchFullName(ginternals.Master))
+	ref := ginternals.NewSymbolicReference(ginternals.Head, ginternals.LocalBranchFullName(branchName))
 	if err := b.WriteReferenceSafe(ref); err != nil {
 		return fmt.Errorf("could not write HEAD: %w", err)
 	}

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -85,7 +85,7 @@ func TestInit(t *testing.T) {
 		dir, cleanup := testhelper.TempDir(t)
 		t.Cleanup(cleanup)
 
-		cfg := confutil.NewCommonConfig(t, dir)
+		cfg := confutil.NewCommonConfigBare(t, dir)
 		b, err := backend.NewFS(cfg)
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -93,6 +93,13 @@ func TestInit(t *testing.T) {
 		})
 
 		require.NoError(t, b.Init(ginternals.Master))
+
+		_, err = os.Stat(filepath.Join(dir, config.DefaultDotGitDirName))
+		require.Error(t, err, "expected .git to not exists")
+		assert.True(t, errors.Is(err, os.ErrNotExist), "invalid error returned")
+
+		_, err = os.Stat(filepath.Join(dir, ginternals.Head))
+		require.NoError(t, err, "expected the HEAD to be at the root of the repo")
 	})
 
 	t.Run("repo with existing data should work", func(t *testing.T) {

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -67,16 +67,12 @@ func TestInit(t *testing.T) {
 		require.NoError(t, b.Init(ginternals.Master))
 
 		// Check the directories that should exists
-		_, err = os.Stat(gitDirPath)
-		assert.NoError(t, err)
-		_, err = os.Stat(objectDirPath)
-		assert.NoError(t, err)
-		_, err = os.Stat(ginternals.ObjectsInfoPath(cfg))
-		assert.NoError(t, err)
+		assert.DirExists(t, gitDirPath)
+		assert.DirExists(t, objectDirPath)
+		assert.DirExists(t, ginternals.ObjectsInfoPath(cfg))
 
 		// Check the directories that should NOT exists
-		_, err = os.Stat(filepath.Join(gitDirPath, "objects"))
-		assert.Error(t, err)
+		assert.NoDirExists(t, filepath.Join(gitDirPath, "objects"))
 	})
 
 	t.Run("bare repo should work", func(t *testing.T) {
@@ -93,13 +89,8 @@ func TestInit(t *testing.T) {
 		})
 
 		require.NoError(t, b.Init(ginternals.Master))
-
-		_, err = os.Stat(filepath.Join(dir, config.DefaultDotGitDirName))
-		require.Error(t, err, "expected .git to not exists")
-		assert.True(t, errors.Is(err, os.ErrNotExist), "invalid error returned")
-
-		_, err = os.Stat(filepath.Join(dir, ginternals.Head))
-		require.NoError(t, err, "expected the HEAD to be at the root of the repo")
+		assert.NoDirExists(t, filepath.Join(dir, config.DefaultDotGitDirName))
+		assert.FileExists(t, filepath.Join(dir, ginternals.Head))
 	})
 
 	t.Run("repo with existing data should work", func(t *testing.T) {

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -33,7 +33,11 @@ func TestInit(t *testing.T) {
 			require.NoError(t, b.Close())
 		})
 
-		require.NoError(t, b.Init())
+		require.NoError(t, b.Init(ginternals.Master))
+
+		data, err := os.ReadFile(filepath.Join(ginternals.DotGitPath(cfg), ginternals.Head))
+		require.NoError(t, err)
+		require.Equal(t, "ref: refs/heads/master\n", string(data))
 	})
 
 	t.Run("repo with separated object dir", func(t *testing.T) {
@@ -60,7 +64,7 @@ func TestInit(t *testing.T) {
 			require.NoError(t, b.Close())
 		})
 
-		require.NoError(t, b.Init())
+		require.NoError(t, b.Init(ginternals.Master))
 
 		// Check the directories that should exists
 		_, err = os.Stat(gitDirPath)
@@ -88,7 +92,7 @@ func TestInit(t *testing.T) {
 			require.NoError(t, b.Close())
 		})
 
-		require.NoError(t, b.Init())
+		require.NoError(t, b.Init(ginternals.Master))
 	})
 
 	t.Run("repo with existing data should work", func(t *testing.T) {
@@ -112,7 +116,7 @@ func TestInit(t *testing.T) {
 			require.NoError(t, b.Close())
 		})
 
-		require.NoError(t, b.Init())
+		require.NoError(t, b.Init(ginternals.Master))
 	})
 
 	t.Run("should fail if directory exists without write perm", func(t *testing.T) {
@@ -136,7 +140,7 @@ func TestInit(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, b.Close())
 		})
-		err = b.Init()
+		err = b.Init(ginternals.Master)
 		require.Error(t, err)
 		var perror *os.PathError
 		require.True(t, errors.As(err, &perror), "error should be os.PathError")
@@ -159,7 +163,7 @@ func TestInit(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, b.Close())
 		})
-		err = b.Init()
+		err = b.Init(ginternals.Master)
 		require.Error(t, err)
 		var perror *os.PathError
 		require.True(t, errors.As(err, &perror), "error should be os.PathError")

--- a/backend/reference_test.go
+++ b/backend/reference_test.go
@@ -92,7 +92,7 @@ func TestParsePackedRefs(t *testing.T) {
 		require.NoError(t, err)
 
 		defer require.NoError(t, b.Close())
-		require.NoError(t, b.Init())
+		require.NoError(t, b.Init(ginternals.Master))
 		return dir, cleanup
 	}
 
@@ -207,7 +207,7 @@ func TestWriteReference(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, b.Close())
 		})
-		require.NoError(t, b.Init())
+		require.NoError(t, b.Init(ginternals.Master))
 
 		ref := ginternals.NewSymbolicReference("HEAD", "refs/heads/master")
 		err = b.WriteReference(ref)
@@ -230,7 +230,7 @@ func TestWriteReference(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, b.Close())
 		})
-		require.NoError(t, b.Init())
+		require.NoError(t, b.Init(ginternals.Master))
 
 		target, err := ginternals.NewOidFromStr("bbb720a96e4c29b9950a4c577c98470a4d5dd089")
 		require.NoError(t, err)
@@ -255,7 +255,7 @@ func TestWriteReference(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, b.Close())
 		})
-		require.NoError(t, b.Init())
+		require.NoError(t, b.Init(ginternals.Master))
 
 		ref := ginternals.NewSymbolicReference("H EAD", "refs/heads/master")
 		err = b.WriteReference(ref)
@@ -335,7 +335,7 @@ func TestWriteReferenceSafe(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, b.Close())
 		})
-		require.NoError(t, b.Init())
+		require.NoError(t, b.Init(ginternals.Master))
 
 		ref := ginternals.NewSymbolicReference("refs/heads/my_feature", "refs/heads/master")
 		err = b.WriteReferenceSafe(ref)
@@ -359,7 +359,7 @@ func TestWriteReferenceSafe(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, b.Close())
 		})
-		require.NoError(t, b.Init())
+		require.NoError(t, b.Init(ginternals.Master))
 
 		target, err := ginternals.NewOidFromStr("bbb720a96e4c29b9950a4c577c98470a4d5dd089")
 		require.NoError(t, err)
@@ -385,7 +385,7 @@ func TestWriteReferenceSafe(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, b.Close())
 		})
-		require.NoError(t, b.Init())
+		require.NoError(t, b.Init(ginternals.Master))
 
 		ref := ginternals.NewSymbolicReference("H EAD", "refs/heads/master")
 		err = b.WriteReferenceSafe(ref)

--- a/cmd/git-go/cat_file.go
+++ b/cmd/git-go/cat_file.go
@@ -15,7 +15,7 @@ import (
 
 var errBadFile = errors.New("bad file")
 
-func newCatFileCmd(cfg *flags) *cobra.Command {
+func newCatFileCmd(cfg *globalFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cat-file [TYPE] OBJECT",
 		Short: "Provide content or type and size information for repository objects",
@@ -50,7 +50,7 @@ type catFileParams struct {
 	prettyPrint bool
 }
 
-func catFileCmd(out io.Writer, cfg *flags, p catFileParams) (err error) {
+func catFileCmd(out io.Writer, cfg *globalFlags, p catFileParams) (err error) {
 	// Validate options
 	if p.typ != "" && (p.typeOnly || p.sizeOnly || p.prettyPrint) {
 		return errors.New("type not supported with options -t, -s, -p")

--- a/cmd/git-go/git.go
+++ b/cmd/git-go/git.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type flags struct {
+type globalFlags struct {
 	env *env.Env
 
 	C        pflag.Value // simpler version of git's -C: https://git-scm.com/docs/git#Documentation/git.txt--Cltpathgt
@@ -24,7 +24,7 @@ func newRootCmd(cwd string, e *env.Env) *cobra.Command {
 		SilenceUsage:  true,
 	}
 
-	cfg := &flags{
+	cfg := &globalFlags{
 		env: e,
 	}
 	cfg.C = pathutil.NewDirPathFlagWithDefault(cwd)

--- a/cmd/git-go/helpers.go
+++ b/cmd/git-go/helpers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Nivl/git-go/ginternals/config"
 )
 
-func loadRepository(cfg *flags) (*git.Repository, error) {
+func loadRepository(cfg *globalFlags) (*git.Repository, error) {
 	p, err := config.LoadConfig(cfg.env, config.LoadConfigOptions{
 		WorkingDirectory: cfg.C.String(),
 		GitDirPath:       cfg.GitDir,

--- a/cmd/git-go/helpers_test.go
+++ b/cmd/git-go/helpers_test.go
@@ -40,7 +40,7 @@ func TestLoadRepository(t *testing.T) {
 		t.Run(fmt.Sprintf("%d/%s", i, tc.desc), func(t *testing.T) {
 			t.Parallel()
 
-			cfg := &flags{
+			cfg := &globalFlags{
 				env: env.NewFromKVList([]string{}),
 				C:   testhelper.NewStringValue(tc.C),
 			}

--- a/cmd/git-go/init.go
+++ b/cmd/git-go/init.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newInitCmd(cfg *flags) *cobra.Command {
+func newInitCmd(cfg *globalFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "init a new git repository",
@@ -21,7 +21,7 @@ func newInitCmd(cfg *flags) *cobra.Command {
 	return cmd
 }
 
-func initCmd(cfg *flags) error {
+func initCmd(cfg *globalFlags) error {
 	p, err := config.LoadConfig(cfg.env, config.LoadConfigOptions{
 		WorkingDirectory: cfg.C.String(),
 		GitDirPath:       cfg.GitDir,

--- a/cmd/git-go/init.go
+++ b/cmd/git-go/init.go
@@ -8,20 +8,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// initCmdFlags represents the flags accepted by the init command
+type initCmdFlags struct {
+	initialBranch string
+}
+
 func newInitCmd(cfg *globalFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "init a new git repository",
 	}
 
+	flags := initCmdFlags{}
+	cmd.Flags().StringVarP(&flags.initialBranch, "initial-branch", "b", "", "Use the specified name for the initial branch in the newly created repository. If not specified, fall back to the default name (currently master, but this is subject to change in the future; the name can be customized via the init.defaultBranch configuration variable).")
+
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return initCmd(cfg)
+		return initCmd(cfg, flags)
 	}
 
 	return cmd
 }
 
-func initCmd(cfg *globalFlags) error {
+func initCmd(cfg *globalFlags, flags initCmdFlags) error {
 	p, err := config.LoadConfig(cfg.env, config.LoadConfigOptions{
 		WorkingDirectory: cfg.C.String(),
 		GitDirPath:       cfg.GitDir,
@@ -34,7 +42,8 @@ func initCmd(cfg *globalFlags) error {
 	}
 
 	r, err := git.InitRepositoryWithParams(p, git.InitOptions{
-		IsBare: cfg.Bare,
+		IsBare:            cfg.Bare,
+		InitialBranchName: flags.initialBranch,
 	})
 	if err != nil {
 		return err

--- a/cmd/git-go/init_test.go
+++ b/cmd/git-go/init_test.go
@@ -57,7 +57,7 @@ func TestInit(t *testing.T) {
 		dirPath, cleanup := testhelper.TempDir(t)
 		t.Cleanup(cleanup)
 
-		err := initCmd(&flags{
+		err := initCmd(&globalFlags{
 			env: env.NewFromKVList([]string{}),
 			C:   &testhelper.StringValue{Value: dirPath},
 		})
@@ -74,7 +74,7 @@ func TestInit(t *testing.T) {
 		dir, cleanup := testhelper.TempDir(t)
 		t.Cleanup(cleanup)
 
-		err := initCmd(&flags{
+		err := initCmd(&globalFlags{
 			env: env.NewFromKVList([]string{}),
 			C:   &testhelper.StringValue{Value: filepath.Join(dir, "this", "path", "is", "fake")},
 		})

--- a/cmd/git-go/init_test.go
+++ b/cmd/git-go/init_test.go
@@ -77,6 +77,31 @@ func TestInit(t *testing.T) {
 		assert.Equal(t, expectedOut, sdtout.String())
 	})
 
+	t.Run("init an existing repo should change the output message", func(t *testing.T) {
+		t.Parallel()
+
+		dirPath, cleanup := testhelper.TempDir(t)
+		t.Cleanup(cleanup)
+
+		// Running once
+		err := initCmd(io.Discard, &globalFlags{
+			env: env.NewFromKVList([]string{}),
+			C:   &testhelper.StringValue{Value: dirPath},
+		}, initCmdFlags{})
+		require.NoError(t, err)
+		// Running twice
+		sdtout := bytes.NewBufferString("")
+		err = initCmd(sdtout, &globalFlags{
+			env: env.NewFromKVList([]string{}),
+			C:   &testhelper.StringValue{Value: dirPath},
+		}, initCmdFlags{})
+		require.NoError(t, err)
+
+		gitDir := filepath.Join(dirPath, config.DefaultDotGitDirName)
+		expectedOut := fmt.Sprintf("Reinitialized existing Git repository in %s\n", gitDir)
+		assert.Equal(t, expectedOut, sdtout.String())
+	})
+
 	t.Run("should create un-existing path", func(t *testing.T) {
 		t.Parallel()
 

--- a/cmd/git-go/init_test.go
+++ b/cmd/git-go/init_test.go
@@ -69,9 +69,7 @@ func TestInit(t *testing.T) {
 		require.NoError(t, err)
 
 		gitDir := filepath.Join(dirPath, config.DefaultDotGitDirName)
-		info, err := os.Stat(gitDir)
-		require.NoError(t, err)
-		assert.True(t, info.IsDir(), "expected .git to be a dir")
+		assert.DirExists(t, gitDir)
 
 		expectedOut := fmt.Sprintf("Initialized empty Git repository in %s\n", gitDir)
 		assert.Equal(t, expectedOut, sdtout.String())

--- a/ginternals/config/config.go
+++ b/ginternals/config/config.go
@@ -77,6 +77,12 @@ type Config struct {
 	SkipSystemConfig bool
 }
 
+// FromFile returns a FileAggregate containing all the config values
+// set in the gitconfig files
+func (cfg *Config) FromFile() *FileAggregate {
+	return cfg.fromFiles
+}
+
 // LoadConfigOptions represents all the params used to set the default
 // values of a Config object
 type LoadConfigOptions struct {

--- a/ginternals/config/config.go
+++ b/ginternals/config/config.go
@@ -42,38 +42,38 @@ type Config struct {
 	// files
 	fromFiles *FileAggregate
 
-	// GitDirPath represents the path to the .git directory
-	// Maps to $GIT_DIR if set
+	// GitDirPath represents the path to the .git directory.
+	// Maps to $GIT_DIR if set.
 	// Defaults to finding a ".git" folder in the current directory,
-	// going up in the tree until reaching /
+	// going up in the tree until reaching /.
 	GitDirPath string
 	// CommonDirPath represents the root path of the non-worktree-related
 	// files that are in the .git directory.
 	// https://git-scm.com/docs/git#Documentation/git.txt-codeGITCOMMONDIRcode
-	// Maps to $GIT_COMMON_DIR
-	// Defaults to $GitDirPath
+	// Maps to $GIT_COMMON_DIR.
+	// Defaults to $GitDirPath.
 	CommonDirPath string
-	// WorkTreePath represents the path to the .git directory
-	// Maps to $GIT_WORK_TREE
+	// WorkTreePath represents the path to the .git directory.
+	// Maps to $GIT_WORK_TREE.
 	// Defaults to $(GitDirPath)/.. or $(current-dir) depending on if
 	// GitDirPath was set or not.
 	WorkTreePath string
-	// ObjectDirPath represents the path to the .git/objects directory
-	// Maps to $GIT_OBJECT_DIRECTORY
-	// Defaults to $(CommonDirPath)/.git/objects
+	// ObjectDirPath represents the path to the .git/objects directory.
+	// Maps to $GIT_OBJECT_DIRECTORY.
+	// Defaults to $(CommonDirPath)/.git/objects.
 	ObjectDirPath string
-	// LocalConfig represents the config file to load
-	// Maps to $GIT_CONFIG
-	// Defaults to $(GitDirPath)/config if not sets
+	// LocalConfig represents the config file to load.
+	// Maps to $GIT_CONFIG.
+	// Defaults to $(GitDirPath)/config if not sets.
 	LocalConfig string
 	// Prefix contains the base for finding the system configuration file.
-	// $(prefix)/etc/gitconfig
-	// Maps to $PREFIX
-	// Defaults to an empty string
+	// $(prefix)/etc/gitconfig.
+	// Maps to $PREFIX.
+	// Defaults to an empty string.
 	Prefix string
-	// SkipSystemConfig states whether we should use the system config or not
-	// Maps to $GIT_CONFIG_NOSYSTEM
-	// Defaults to false
+	// SkipSystemConfig states whether we should use the system config or not.
+	// Maps to $GIT_CONFIG_NOSYSTEM.
+	// Defaults to false.
 	SkipSystemConfig bool
 }
 
@@ -86,12 +86,12 @@ func (cfg *Config) FromFile() *FileAggregate {
 // LoadConfigOptions represents all the params used to set the default
 // values of a Config object
 type LoadConfigOptions struct {
-	// FS represents the file system implementation to use to look for
+	// FS represents the file system implementation to use to look for.
 	// files and directories.
 	// Defaults to the regular filesystem.
 	FS afero.Fs
-	// WorkingDirectory represents the current working directory
-	// Defaults to the current working directory
+	// WorkingDirectory represents the current working directory.
+	// Defaults to the current working directory.
 	WorkingDirectory string
 	// WorkTreePath corresponds to the directory that should contain the .git.
 	// Set this value to change the default behavior and overwrite

--- a/ginternals/config/config_test.go
+++ b/ginternals/config/config_test.go
@@ -231,6 +231,22 @@ func TestLoadConfig(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		{
+			desc: "bare repo should not point to a .git",
+			cfg: LoadConfigOptions{
+				WorkingDirectory: "wd",
+				IsBare:           true,
+			},
+			e: env.NewFromKVList([]string{}),
+			expectedParams: &Config{
+				WorkTreePath:  "",
+				GitDirPath:    filepath.Join(cwd, "wd"),
+				CommonDirPath: filepath.Join(cwd, "wd"),
+				LocalConfig:   filepath.Join(cwd, "wd", "config"),
+				ObjectDirPath: filepath.Join(cwd, "wd", "objects"),
+			},
+			expectedError: nil,
+		},
 	}
 	for i, tc := range testCases {
 		tc := tc

--- a/ginternals/config/file_aggregate.go
+++ b/ginternals/config/file_aggregate.go
@@ -37,6 +37,17 @@ func (cfg *FileAggregate) RepoFormatVersion() (version int, ok bool) {
 	return v, true
 }
 
+// DefaultBranch returns the branch name to use when creating a new
+// repository.
+// The branch name isn't checked and may be an invalid value
+func (cfg *FileAggregate) DefaultBranch() (name string, ok bool) {
+	v := cfg.agg.Section("init").Key("defaultBranch").String()
+	if v == "" {
+		return "", false
+	}
+	return v, true
+}
+
 // WorkTree returns the path of the work-tree
 func (cfg *FileAggregate) WorkTree() (workTree string, ok bool) {
 	v := cfg.agg.Section("core").Key("worktree").String()

--- a/internal/pathutil/working_tree.go
+++ b/internal/pathutil/working_tree.go
@@ -25,8 +25,21 @@ func WorkingTreeFromPath(p, dotGitDirName string) (path string, err error) {
 	prev := ""
 	for p != prev {
 		info, err := os.Stat(filepath.Join(p, dotGitDirName))
-		if err == nil && info.IsDir() {
-			return p, nil
+		if err == nil {
+			// A file named .git is valid, this file should contain a
+			// gitdir instruction with a path to the repo.
+			if !info.IsDir() {
+				return p, nil
+			}
+
+			// in case the .git is a directory, we need to check the directory
+			// has a HEAD to validate that it's an actual git repo
+			head, err := os.Stat(filepath.Join(p, dotGitDirName, "HEAD"))
+			if err == nil {
+				if !head.IsDir() {
+					return p, nil
+				}
+			}
 		}
 
 		prev = p

--- a/internal/pathutil/working_tree_test.go
+++ b/internal/pathutil/working_tree_test.go
@@ -14,13 +14,51 @@ import (
 func TestWorkingTreeFromPath(t *testing.T) {
 	t.Parallel()
 
-	t.Run("should be found fom subdir", func(t *testing.T) {
+	t.Run(".git dir without head shouldn't be returned", func(t *testing.T) {
 		t.Parallel()
 
 		path, cleanup := testhelper.TempDir(t)
 		t.Cleanup(cleanup)
 
 		err := os.MkdirAll(filepath.Join(path, ".git"), 0o755)
+		require.NoError(t, err)
+
+		finalPath := filepath.Join(path, "a", "b", "c")
+		err = os.MkdirAll(finalPath, 0o755)
+		require.NoError(t, err)
+
+		_, err = pathutil.WorkingTreeFromPath(finalPath, ".git")
+		require.Error(t, err)
+		require.Equal(t, pathutil.ErrNoRepo, err)
+	})
+
+	t.Run(".git file should be returned", func(t *testing.T) {
+		t.Parallel()
+
+		path, cleanup := testhelper.TempDir(t)
+		t.Cleanup(cleanup)
+
+		err := os.WriteFile(filepath.Join(path, ".git"), []byte(""), 0o644)
+		require.NoError(t, err)
+
+		finalPath := filepath.Join(path, "a", "b", "c")
+		err = os.MkdirAll(finalPath, 0o755)
+		require.NoError(t, err)
+
+		p, err := pathutil.WorkingTreeFromPath(finalPath, ".git")
+		require.NoError(t, err)
+		assert.Equal(t, path, p)
+	})
+
+	t.Run(".git dir with head should be returned", func(t *testing.T) {
+		t.Parallel()
+
+		path, cleanup := testhelper.TempDir(t)
+		t.Cleanup(cleanup)
+
+		err := os.MkdirAll(filepath.Join(path, ".git"), 0o755)
+		require.NoError(t, err)
+		err = os.WriteFile(filepath.Join(path, ".git", "HEAD"), []byte(""), 0o644)
 		require.NoError(t, err)
 
 		finalPath := filepath.Join(path, "a", "b", "c")

--- a/repo.go
+++ b/repo.go
@@ -53,6 +53,9 @@ type InitOptions struct {
 	InitialBranchName string
 	// IsBare represents whether a bare repository will be created or not
 	IsBare bool
+	// Symlink will create a .git text file in the working tree that points
+	// toward the actual repository
+	Symlink bool
 }
 
 // InitRepository initialize a new git repository by creating the .git
@@ -158,7 +161,7 @@ func InitRepositoryWithParams(cfg *config.Config, opts InitOptions) (r *Reposito
 		}(r)
 	}
 
-	if err = r.dotGit.Init(branchName); err != nil {
+	if err = r.dotGit.InitWithSymlink(branchName, opts.Symlink); err != nil {
 		return nil, err
 	}
 

--- a/repo.go
+++ b/repo.go
@@ -17,7 +17,6 @@ import (
 var (
 	ErrRepositoryNotExist           = errors.New("repository does not exist")
 	ErrRepositoryUnsupportedVersion = errors.New("repository nor supported")
-	ErrRepositoryExists             = errors.New("repository already exists")
 	ErrTagNotFound                  = errors.New("tag not found")
 	ErrTagExists                    = errors.New("tag already exists")
 	ErrNotADirectory                = errors.New("not a directory")
@@ -101,7 +100,7 @@ func InitRepositoryWithOptions(rootPath string, opts InitOptions) (r *Repository
 // Git stores and manipulates is located.
 // https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain#ch10-git-internals
 //
-// This assumes methods makes no assumptions
+// This method makes no assumptions
 func InitRepositoryWithParams(cfg *config.Config, opts InitOptions) (r *Repository, err error) {
 	r = &Repository{
 		Config: cfg,
@@ -160,9 +159,6 @@ func InitRepositoryWithParams(cfg *config.Config, opts InitOptions) (r *Reposito
 	}
 
 	if err = r.dotGit.Init(branchName); err != nil {
-		if errors.Is(err, ginternals.ErrRefExists) {
-			return nil, ErrRepositoryExists
-		}
 		return nil, err
 	}
 

--- a/repo_test.go
+++ b/repo_test.go
@@ -213,6 +213,29 @@ func TestInit(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, err, ErrInvalidBranchName)
 	})
+
+	t.Run("Bare repo", func(t *testing.T) {
+		t.Parallel()
+
+		// Setup
+		d, cleanup := testhelper.TempDir(t)
+		t.Cleanup(cleanup)
+
+		// Run logic
+		r, err := InitRepositoryWithOptions(d, InitOptions{
+			IsBare: true,
+		})
+		require.NoError(t, err, "failed creating a repo")
+		t.Cleanup(func() {
+			require.NoError(t, r.Close(), "failed closing repo")
+		})
+		_, err = os.Stat(filepath.Join(d, config.DefaultDotGitDirName))
+		require.Error(t, err, "expected .git to not exists")
+		assert.True(t, errors.Is(err, os.ErrNotExist), "invalid error returned")
+
+		_, err = os.Stat(filepath.Join(d, ginternals.Head))
+		require.NoError(t, err, "expected the HEAD to be at the root of the repo")
+	})
 }
 
 func TestOpen(t *testing.T) {

--- a/repo_test.go
+++ b/repo_test.go
@@ -133,7 +133,7 @@ func TestInit(t *testing.T) {
 		}
 	})
 
-	t.Run("should fail with a repo that already exists", func(t *testing.T) {
+	t.Run("should NOT fail with a repo that already exists", func(t *testing.T) {
 		t.Parallel()
 
 		// Setup
@@ -141,9 +141,9 @@ func TestInit(t *testing.T) {
 		t.Cleanup(cleanup)
 
 		// Run logic
-		_, err := InitRepository(repoPath)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrRepositoryExists)
+		r, err := InitRepository(repoPath)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
 	})
 
 	// Windows deals with permission differently

--- a/repo_test.go
+++ b/repo_test.go
@@ -229,12 +229,8 @@ func TestInit(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, r.Close(), "failed closing repo")
 		})
-		_, err = os.Stat(filepath.Join(d, config.DefaultDotGitDirName))
-		require.Error(t, err, "expected .git to not exists")
-		assert.True(t, errors.Is(err, os.ErrNotExist), "invalid error returned")
-
-		_, err = os.Stat(filepath.Join(d, ginternals.Head))
-		require.NoError(t, err, "expected the HEAD to be at the root of the repo")
+		assert.NoFileExists(t, filepath.Join(d, config.DefaultDotGitDirName))
+		assert.FileExists(t, filepath.Join(d, ginternals.Head))
 	})
 }
 
@@ -403,8 +399,7 @@ func TestRepositoryNewBlob(t *testing.T) {
 
 	// make sure the blob was persisted
 	p := ginternals.LooseObjectPath(r.Config, blob.ID().String())
-	_, err = os.Stat(p)
-	require.NoError(t, err)
+	assert.FileExists(t, p)
 }
 
 func TestRepositoryGetCommit(t *testing.T) {

--- a/tree_builder_test.go
+++ b/tree_builder_test.go
@@ -3,7 +3,6 @@ package git
 import (
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/Nivl/git-go/ginternals"
@@ -282,8 +281,7 @@ func TestTreeBuilderWrite(t *testing.T) {
 		assert.Len(t, tb.entries, 2)
 
 		p := ginternals.LooseObjectPath(r.Config, tree.ID().String())
-		_, err = os.Stat(p)
-		require.NoError(t, err)
+		assert.FileExists(t, p)
 	})
 
 	t.Run("building an existing tree should return the same data", func(t *testing.T) {


### PR DESCRIPTION
Add support for all (or most) options of the [init command](https://git-scm.com/docs/git-init)

- 1 Commit per flag / refactor
- The PR won't be squashed

The following options will be done in their own PRs since they require a larger refactoring / more thinking:

- [ ] --object-format
- [ ] --shared
- [ ] --template